### PR TITLE
Log sentry-cli output while the command is still running

### DIFF
--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -33,11 +33,11 @@ module Fastlane
         end
         final_command = command.map { |arg| Shellwords.escape(arg) }.join(" ")
         Open3.popen3(final_command) do |stdin, stdout, stderr, wait_thr|
-          while (line = stderr.gets)
-            error << line.strip!
-          end
           while (line = stdout.gets)
             UI.message(line.strip!)
+          end
+          while (line = stderr.gets)
+            error << line.strip!
           end
           exit_status = wait_thr.value
           unless exit_status.success? && error.empty?


### PR DESCRIPTION
`gets` will wait for more output to be produced if the stream is not
yet closed. Since only stdout is forwarded, it should be handled
before stderr, and logged to the user as it comes in. After the
command has finished, stderr is read and buffered to completion.