### PR TITLE
feat: allow ignoring files when uploading sourcemaps

### DIFF
--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -27,6 +27,18 @@ module Fastlane
         command.push('--url-prefix').push(params[:url_prefix]) unless params[:url_prefix].nil?
         command.push('--dist').push(params[:dist]) unless params[:dist].nil?
 
+        unless params[:ignore].nil?
+          # normalize to array
+          unless params[:ignore].kind_of?(Enumerable)
+            params[:ignore] = [params[:ignore]]
+          end
+          # no nil or empty strings
+          params[:ignore].reject! { |e| e.strip.empty? rescue true }
+          command.push('--ignore').push(*params[:ignore]) if params[:ignore].any?
+        end
+
+        command.push('--ignore-file').push(params[:ignore_file]) unless params[:ignore_file].nil?
+
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded files to release: #{version}")
       end
@@ -82,6 +94,13 @@ module Fastlane
                                        short_option: "-a",
                                        env_name: "SENTRY_APP_IDENTIFIER",
                                        description: "App Bundle Identifier, prepended to version",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :ignore,
+                                       description: "Ignores all files and folders matching the given glob or array of globs",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :ignore_file,
+                                       description: "Ignore all files and folders specified in the given ignore file, e.g. .gitignore",
                                        optional: true)
 
         ]


### PR DESCRIPTION
Mirror sentry-cli options for `--ignore` and `--ignore-file` for sentry_upload_sourcemap

Refs #52