### PR TITLE
Remove version escaping in sentry_upload_sourcemaps

### DIFF
--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -16,7 +16,7 @@ module Fastlane
           "sentry-cli",
           "releases",
           "files",
-          Shellwords.escape(version),
+          version,
           "upload-sourcemaps",
           sourcemap.to_s
         ]


### PR DESCRIPTION
To harmonize with other actions, I propose to delete the version's escaping for `sentry_upload_sourcemaps`, which is causing some issues with the version number. 
This PR will resolve #57.