### PR TITLE
fix: Align release name format with Sentry releases

### DIFF
--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -8,7 +8,7 @@ module Fastlane
         Helper::SentryConfig.parse_api_params(params)
 
         version = params[:version]
-        version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
+        version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",

--- a/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
@@ -8,7 +8,7 @@ module Fastlane
         Helper::SentryConfig.parse_api_params(params)
 
         version = params[:version]
-        version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
+        version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -8,7 +8,7 @@ module Fastlane
         Helper::SentryConfig.parse_api_params(params)
 
         version = params[:version]
-        version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
+        version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -10,7 +10,7 @@ module Fastlane
         file = params[:file]
 
         version = params[:version]
-        version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
+        version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -10,7 +10,7 @@ module Fastlane
         version = params[:version]
         sourcemap = params[:sourcemap]
 
-        version = "#{params[:app_identifier]}-#{params[:version]}" if params[:app_identifier]
+        version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
 
         command = [
           "sentry-cli",

--- a/spec/sentry_create_release_spec.rb
+++ b/spec/sentry_create_release_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "app.idf-1.0"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "app.idf@1.0"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_create_release(

--- a/spec/sentry_set_commits_spec.rb
+++ b/spec/sentry_set_commits_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "set-commits", "app.idf-1.0"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "set-commits", "app.idf@1.0"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_set_commits(

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane do
       it "does not require dist to be specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload", "demo.file"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload", "demo.file"]).and_return(true)
 
         allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("demo.file").and_return(true)
@@ -37,7 +37,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload", "demo.file", "--dist", "dem"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload", "demo.file", "--dist", "dem"]).and_return(true)
 
         allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("demo.file").and_return(true)

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane do
       it "does not require dist to be specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload-sourcemaps", "1.map", "--no-rewrite"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.map", "--no-rewrite"]).and_return(true)
 
         allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("1.map").and_return(true)
@@ -37,7 +37,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf-1.0", "upload-sourcemaps", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
 
         allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("1.map").and_return(true)


### PR DESCRIPTION
When creating Sentry releases through these actions, Sentry events would come through that wouldn't tie to those specific releases and would instead create a duplicate release. This is because Sentry expects an `@` between the app/bundle identifier and the version/build number instead of the `-` that is currently seperating the two.