### PR TITLE
fix: Fix bitcode processing with sentry-cli

### DIFF
--- a/lib/fastlane/plugin/sentry/version.rb
+++ b/lib/fastlane/plugin/sentry/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Sentry
     VERSION = "1.8.0"
-    CLI_VERSION = "1.58.0"
+    CLI_VERSION = "1.63.1"
   end
 end


### PR DESCRIPTION
The [1.63.1](https://github.com/getsentry/sentry-cli/releases/tag/1.63.1) release for sentry-cli contains an important fix for processing dSYMS with BCSymbolMaps. Therefore we set the minimum sentry-cli version to 1.63.1.