### PR TITLE
feat: Add an action to check sentry-cli is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - feat: Add default value `.` for path param of `sentry_upload_dif` action ([#94](https://github.com/getsentry/sentry-fastlane-plugin/pull/94))
+- feat: Add an action to check sentry-cli is installed([#78](https://github.com/getsentry/sentry-fastlane-plugin/pull/78))
 
 ## 1.9.0
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ sentry_create_deploy(
 )
 ```
 
+#### Checking the sentry-cli is installed
+
+Useful for checking that the sentry-cli is installed and meets the minimum version requirements before starting to build your app in your lane.
+
+```ruby
+sentry_check_cli_installed()
+```
+
 ## Issues and Feedback
 
 For any other issues and feedback about this plugin, please submit it to this repository.

--- a/lib/fastlane/plugin/sentry/actions/sentry_check_cli_installed.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_check_cli_installed.rb
@@ -1,0 +1,37 @@
+module Fastlane
+  module Actions
+    class SentryCheckCliInstalledAction < Action
+      def self.run(params)
+        Helper::SentryHelper.check_sentry_cli!
+        UI.success("Successfully checked that sentry-cli is installed")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Checks that sentry-cli with the correct version is installed"
+      end
+
+      def self.details
+        [
+          "This action checks that the senty-cli is installed and meets the mimum verson requirements.",
+          "You can use it at the start of your lane to ensure that sentry-cli is correctly installed."
+        ].join(" ")
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["matt-oakes"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/spec/sentry_check_cli_installed_spec.rb
+++ b/spec/sentry_check_cli_installed_spec.rb
@@ -1,0 +1,13 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "check cli installed" do
+      it "success when check_sentry_cli true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_check_cli_installed()
+        end").runner.execute(:test)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a new action which will only pass if the sentry-cli is installed and meets the minimum version.

This is intended to be used at the start of the lane to ensure the machine is setup correctly before preceding to build and upload the app. This avoids long waits just to see that the Sentry upload will fail later on, which might leave some builds being uploaded to the App Store without source maps also being uploaded.