### PR TITLE
Allow manually specifying android mapping-uuid 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,16 +93,60 @@ sentry_upload_sourcemap(
 
 #### Uploading Proguard Mapping File
 
+Upload by passing `AndroidManifest.xml` file reference
+
 ```ruby
 sentry_upload_proguard(
   api_key: '...', # Do not use if using auth_token
   auth_token: '...', # Do not use if using api_key
   org_slug: '...',
   project_slug: '...',
-  android_manifest_path: 'path to merged AndroidManifest file' # found in `app/build/intermediates/manifests/full`
-  mapping_path: 'path to mapping.txt to upload',
+  android_manifest_path: 'path to merged AndroidManifest file', # found in `app/build/intermediates/manifests/full`
+  mapping_path: 'path to mapping.txt to upload'
 )
 ```
+
+Upload by passing mapping properties by hand
+
+```ruby
+sentry_upload_proguard(
+  api_key: '...', # Do not use if using auth_token
+  auth_token: '...', # Do not use if using api_key
+  org_slug: '...',
+  project_slug: '...',
+  app_id: '...',
+  version_name: "1.2.3",
+  version_code: 45,
+  uuid: '...',
+  mapping_path: 'path to mapping.txt to upload'
+)
+```
+
+<details>
+    <summary>Advanced usage</summary>
+
+`sentry_upload_proguard` handles almost all `sentry-cli` flags
+
+```ruby
+sentry_upload_proguard(
+  api_key: '...', # Do not use if using auth_token
+  auth_token: '...', # Do not use if using api_key
+  org_slug: '...',
+  project_slug: '...',
+  android_manifest_path: 'path to merged AndroidManifest file',
+  app_id: '...',
+  no_reprocessing: true,
+  no_upload: true,
+  platform: '...',
+  require_one: true,
+  uuid: '...',
+  version: '...',
+  version_code: 45,
+  mapping_path: 'path to mapping.txt to upload')
+```
+
+Reference: [`sentry-cli` documentation](https://docs.sentry.io/product/cli/dif/#proguard-mapping-upload)
+</details>
 
 #### Associating commits
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_proguard.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_proguard.rb
@@ -9,17 +9,24 @@ module Fastlane
         mapping_path = params[:mapping_path]
         android_manifest_path = params[:android_manifest_path]
 
+        has_manifest = !android_manifest_path.nil? && File.file?(android_manifest_path.to_s)
+
         # Verify files
         UI.user_error!("Mapping file does not exist at path: #{mapping_path}") unless File.exist? mapping_path
-        UI.user_error!("AndroidManifest.xml file does not exist at path: #{android_manifest_path}") unless File.exist? android_manifest_path
 
-        command = [
-          "sentry-cli",
-          "upload-proguard",
-          "--android-manifest",
-          android_manifest_path,
-          mapping_path
-        ]
+        # Create command
+        command = %w[sentry-cli upload-proguard]
+        command += ["--android-manifest", android_manifest_path] if has_manifest
+        command += ["--app-id", params[:app_id]] unless params[:app_id].nil?
+        command += ["--no-reprocessing"] if !!params[:no_reprocessing]
+        command += ["--no-upload"] if !!params[:no_upload]
+        command += ["--platform", params[:platform]] unless params[:platform].nil?
+        command += ["--require-one"] if !!params[:require_one]
+        command += ["--uuid", params[:uuid]] unless params[:uuid].nil?
+        command += ["--version", params[:version]] unless params[:version].nil?
+        command += ["--version-code", params[:version_code]] unless params[:version_code].nil?
+
+        command += [mapping_path]
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully uploaded mapping file!")
@@ -43,19 +50,58 @@ module Fastlane
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :mapping_path,
-                                      env_name: "ANDROID_MAPPING_PATH",
-                                      description: "Path to your proguard mapping.txt file",
-                                      optional: false,
-                                      verify_block: proc do |value|
-                                        UI.user_error! "Could not find your mapping file at path '#{value}'" unless File.exist?(value)
-                                      end),
+                                       env_name: "ANDROID_MAPPING_PATH",
+                                       description: "Path to your proguard mapping.txt file",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find your mapping file at path '#{value}'" unless File.exist?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :android_manifest_path,
-                                      env_name: "ANDROID_MANIFEST_PATH",
-                                      description: "Path to your merged AndroidManifest file. This is usually found under `app/build/intermediates/manifests/full`",
-                                      optional: false,
-                                      verify_block: proc do |value|
-                                        UI.user_error! "Could not find your merged AndroidManifest file at path '#{value}'" unless File.exist?(value)
-                                      end)
+                                       env_name: "ANDROID_MANIFEST_PATH",
+                                       description: "Path to your merged AndroidManifest file. This is usually found under `app/build/intermediates/manifests/full`",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error! "Could not find your merged AndroidManifest file at path '#{value}'" unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_id,
+                                       env_name: "APP_ID",
+                                       description: "Associate the mapping files with an application ID",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :no_reprocessing,
+                                       env_name: "NO_REPROCESSING",
+                                       description: "Do not trigger reprocessing after upload",
+                                       is_string: false,
+                                       default_value: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :no_upload,
+                                       env_name: "NO_UPLOAD",
+                                       description: "Disable the actual upload",
+                                       is_string: false,
+                                       default_value: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       env_name: "PLATFORM",
+                                       description: "Optionally defines the platform for the app association. [defaults to 'android']",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :require_one,
+                                       env_name: "REQUIRE_ONE",
+                                       description: "Requires at least one file to upload or the command will error",
+                                       is_string: false,
+                                       default_value: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :uuid,
+                                       env_name: "UUID",
+                                       description: "Explicitly override the UUID of the mapping file with another one",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "VERSION_NAME",
+                                       description: "Optionally associate the mapping files with a human readable version",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :version_code,
+                                       env_name: "VERSION_CODE",
+                                       description: "Optionally associate the mapping files with a version code",
+                                       is_string: false,
+                                       optional: true)
         ]
       end
 

--- a/spec/sentry_upload_proguard_spec.rb
+++ b/spec/sentry_upload_proguard_spec.rb
@@ -49,6 +49,116 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find your merged AndroidManifest file at path '#{android_manifest_path}'")
       end
+
+      it "accepts valid android manifest path and missing mapping uuid" do
+        mapping_path = File.absolute_path './assets/AndroidExample.mapping.txt'
+        android_manifest_path = File.absolute_path './assets/AndroidManifest.xml'
+
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+          ["sentry-cli", "upload-proguard", "--android-manifest", android_manifest_path, mapping_path]
+        ).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_proguard(
+              org_slug: 'some_org',
+              auth_token: 'something123',
+              project_slug: 'some_project',
+              mapping_path: '#{mapping_path}',
+              android_manifest_path: '#{android_manifest_path}')
+        end").runner.execute(:test)
+      end
+
+      it "accepts valid mapping uuid and app id" do
+        mapping_path = File.absolute_path './assets/AndroidExample.mapping.txt'
+        mapping_uuid = "c96e0f5a-8dc5-11eb-8dcd-0242ac130003"
+        android_app_id = "com.example.app.id"
+
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+          ["sentry-cli", "upload-proguard", "--app-id", android_app_id, "--uuid", mapping_uuid, mapping_path]
+        ).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_proguard(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              app_id: '#{android_app_id}',
+              uuid: '#{mapping_uuid}',
+              mapping_path: '#{mapping_path}')
+        end").runner.execute(:test)
+      end
+
+      it "accepts false flags" do
+        mapping_path = File.absolute_path './assets/AndroidExample.mapping.txt'
+        android_manifest_path = File.absolute_path './assets/AndroidManifest.xml'
+
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+          ["sentry-cli", "upload-proguard", "--android-manifest", android_manifest_path, mapping_path]
+        ).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_proguard(
+              org_slug: 'some_org',
+              auth_token: 'something123',
+              project_slug: 'some_project',
+              android_manifest_path: '#{android_manifest_path}',
+              no_reprocessing: false,
+              no_upload: false,
+              require_one: false,
+              mapping_path: '#{mapping_path}')
+        end").runner.execute(:test)
+      end
+
+      it "accepts all supported cli parameters" do
+        mapping_path = File.absolute_path './assets/AndroidExample.mapping.txt'
+        android_manifest_path = File.absolute_path './assets/AndroidManifest.xml'
+        mapping_uuid = "c96e0f5a-8dc5-11eb-8dcd-0242ac130003"
+        android_app_id = "com.example.app.id"
+        platform = "fushia"
+        version_name = "1.2.3-test"
+        version_code = 45
+
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+          [
+            "sentry-cli", "upload-proguard", "--android-manifest", android_manifest_path, "--app-id", android_app_id,
+            "--no-reprocessing", "--no-upload", "--platform", platform, "--require-one", "--uuid", mapping_uuid,
+            "--version", version_name, "--version-code", version_code, mapping_path
+          ]
+        ).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_proguard(
+              org_slug: 'some_org',
+              auth_token: 'something123',
+              project_slug: 'some_project',
+              android_manifest_path: '#{android_manifest_path}',
+              app_id: '#{android_app_id}',
+              no_reprocessing: true,
+              no_upload: true,
+              platform: '#{platform}',
+              require_one: true,
+              uuid: '#{mapping_uuid}',
+              version: '#{version_name}',
+              version_code: #{version_code},
+              mapping_path: '#{mapping_path}')
+        end").runner.execute(:test)
+      end
     end
   end
 end


### PR DESCRIPTION
#79

I gave it a try and tried adding `uuid` support to the plugin. I basically allow passing almost all `sentry-cli` parameters, leaving the validation up to `sentry-cli`.

Please note I'm not familiar with Ruby so I havily relied on other parts of the codebase + code hints and Rubocop offenses that were highlithed. I also didn't know how to write proper tests, I only found ones relying on mocks so I don't actually know if the feature works now. 