### PR TITLE
feat: Sentry Create Deploy Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ sentry_set_commits(
 )
 ```
 
+#### Create deploy
+
+Creates a new release deployment for a project on Sentry.
+
+```ruby
+sentry_create_deploy(
+  version: '...',
+  app_identifier: '...', # pass in the bundle_identifer of your app
+  env: 'staging', # The environment for this deploy. Required.
+  name: '...', # Optional human readable name
+  deploy_url: '...', # Optional URL that points to the deployment
+  started: 1622630647, # Optional unix timestamp when the deployment started
+  finished: 1622630700, # Optional unix timestamp when the deployment finished
+  time: 180 # Optional deployment duration in seconds. This can be specified alternatively to `started` and `finished`
+)
+```
+
 ## Issues and Feedback
 
 For any other issues and feedback about this plugin, please submit it to this repository.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Creates a new release deployment for a project on Sentry.
 
 ```ruby
 sentry_create_deploy(
+  api_key: '...', # Do not use if using auth_token
+  auth_token: '...', # Do not use if using api_key
+  org_slug: '...',
+  project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
   env: 'staging', # The environment for this deploy. Required.

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -9,6 +9,13 @@ module Fastlane
 
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        
+        has_started = !params[:started].nil?
+        has_finished = !params[:finished].nil?
+
+        if has_started && !has_finished || !has_started && has_finished
+          UI.user_error!("Only one parmeter of 'started' and 'finished' found, please provide both.")
+        end
 
         command = [
           "sentry-cli",
@@ -20,8 +27,8 @@ module Fastlane
         command.push('--env').push(params[:env]) unless params[:env].nil?
         command.push('--name').push(params[:name]) unless params[:name].nil?
         command.push('--url').push(params[:deploy_url]) unless params[:deploy_url].nil?
-        command.push('--started').push(params[:started]) unless params[:started].nil?
-        command.push('--finished').push(params[:finished]) unless params[:finished].nil?
+        command.push('--started').push(params[:started]) unless params[:started].nil? || !params[:time].nil?
+        command.push('--finished').push(params[:finished]) unless params[:finished].nil? || !params[:time].nil?
         command.push('--time').push(params[:time]) unless params[:time].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -19,7 +19,7 @@ module Fastlane
         ]
         command.push('--env').push(params[:env]) unless params[:env].nil?
         command.push('--name').push(params[:name]) unless params[:name].nil?
-        # command.push('--url').push(params[:url]) unless params[:url].nil?
+        command.push('--url').push(params[:deploy_url]) unless params[:deploy_url].nil?
         command.push('--started').push(params[:started]) unless params[:started].nil?
         command.push('--finished').push(params[:finished]) unless params[:finished].nil?
         command.push('--time').push(params[:time]) unless params[:time].nil?
@@ -55,10 +55,9 @@ module Fastlane
                                        short_option: "-n",
                                        description: "Optional human readable name for this deployment",
                                        optional: true),
-          # FastlaneCore::ConfigItem.new(key: :url,
-          #                              short_option: "-u",
-          #                              description: "Optional URL that points to the deployment",
-          #                              optional: true),
+          FastlaneCore::ConfigItem.new(key: :deploy_url,
+                                       description: "Optional URL that points to the deployment",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :started,
                                        description: "Optional unix timestamp when the deployment started",
                                        is_string: false,

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -10,14 +10,6 @@ module Fastlane
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
 
-        has_time = !params[:time].nil?
-        has_started = !params[:started].nil?
-        has_finished = !params[:finished].nil?
-
-        if !has_time && (has_started && !has_finished || !has_started && has_finished)
-          UI.user_error!("Only one parmeter of 'started' and 'finished' found, please provide both.")
-        end
-
         command = [
           "sentry-cli",
           "releases",
@@ -28,8 +20,8 @@ module Fastlane
         command.push('--env').push(params[:env]) unless params[:env].nil?
         command.push('--name').push(params[:name]) unless params[:name].nil?
         command.push('--url').push(params[:deploy_url]) unless params[:deploy_url].nil?
-        command.push('--started').push(params[:started]) unless params[:started].nil? || has_time
-        command.push('--finished').push(params[:finished]) unless params[:finished].nil? || has_time
+        command.push('--started').push(params[:started]) unless params[:started].nil?
+        command.push('--finished').push(params[:finished]) unless params[:finished].nil?
         command.push('--time').push(params[:time]) unless params[:time].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -9,11 +9,12 @@ module Fastlane
 
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
-        
+
+        has_time = !params[:time].nil?
         has_started = !params[:started].nil?
         has_finished = !params[:finished].nil?
 
-        if has_started && !has_finished || !has_started && has_finished
+        if !has_time && (has_started && !has_finished || !has_started && has_finished)
           UI.user_error!("Only one parmeter of 'started' and 'finished' found, please provide both.")
         end
 
@@ -27,8 +28,8 @@ module Fastlane
         command.push('--env').push(params[:env]) unless params[:env].nil?
         command.push('--name').push(params[:name]) unless params[:name].nil?
         command.push('--url').push(params[:deploy_url]) unless params[:deploy_url].nil?
-        command.push('--started').push(params[:started]) unless params[:started].nil? || !params[:time].nil?
-        command.push('--finished').push(params[:finished]) unless params[:finished].nil? || !params[:time].nil?
+        command.push('--started').push(params[:started]) unless params[:started].nil? || has_time
+        command.push('--finished').push(params[:finished]) unless params[:finished].nil? || has_time
         command.push('--time').push(params[:time]) unless params[:time].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -21,7 +21,7 @@ module Fastlane
         command.push('--name').push(params[:name]) unless params[:name].nil?
         # command.push('--url').push(params[:url]) unless params[:url].nil?
         command.push('--started').push(params[:started]) unless params[:started].nil?
-        command.push('--finished').push(params[:time]) unless params[:finished].nil?
+        command.push('--finished').push(params[:finished]) unless params[:finished].nil?
         command.push('--time').push(params[:time]) unless params[:time].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -46,7 +46,7 @@ module Fastlane
 
       def self.details
         [
-          "This action allows you to accociate deploys to releases for a project on Sentry.",
+          "This action allows you to associate deploys to releases for a project on Sentry.",
           "See https://docs.sentry.io/product/cli/releases/#creating-deploys for more information."
         ].join(" ")
       end
@@ -54,7 +54,7 @@ module Fastlane
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :version,
-                                       description: "Release version to accociate the deloy with on Sentry"),
+                                       description: "Release version to associate the deploy with on Sentry"),
           FastlaneCore::ConfigItem.new(key: :env,
                                        short_option: "-e",
                                        description: "Set the environment for this release. This argument is required. Values that make sense here would be 'production' or 'staging'",

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -1,0 +1,96 @@
+module Fastlane
+  module Actions
+    class SentryCreateDeployAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryHelper.check_sentry_cli!
+        Helper::SentryConfig.parse_api_params(params)
+
+        version = params[:version]
+        version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+
+        command = [
+          "sentry-cli",
+          "releases",
+          "deploys",
+          version,
+          "new"
+        ]
+        command.push('--env').push(params[:env]) unless params[:env].nil?
+        command.push('--name').push(params[:name]) unless params[:name].nil?
+        command.push('--url').push(params[:url]) unless params[:url].nil?
+        command.push('--started').push(params[:started]) unless params[:started].nil?
+        command.push('--finished').push(params[:time]) unless params[:finished].nil?
+        command.push('--time').push(params[:time]) unless params[:time].nil?
+
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully created deploy: #{version}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Creates a new release deployment for a project on Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to accociate deploys to releases for a project on Sentry.",
+          "See https://docs.sentry.io/product/cli/releases/#creating-deploys for more information."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Release version to accociate the deloy with on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :env,
+                                       short_option: "-e",
+                                       description: "Set the environment for this release. This argument is required. Values that make sense here would be 'production' or 'staging'.",
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :name,
+                                       short_option: "-n",
+                                       description: "Optional human readable name for this deployment.",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :url,
+                                       short_option: "-u",
+                                       description: "Optional URL that points to the deployment.",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :started,
+                                       description: "Optional unix timestamp when the deployment started.",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :finished,
+                                       description: "Optional unix timestamp when the deployment finished.",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :time,
+                                       short_option: "-t",
+                                       description: "Optional deployment duration in seconds. This can be specified alternatively to `--started` and `--finished`.",
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                       short_option: "-a",
+                                       env_name: "SENTRY_APP_IDENTIFIER",
+                                       description: "App Bundle Identifier, prepended to version",
+                                       optional: true)
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["denrase"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -19,7 +19,7 @@ module Fastlane
         ]
         command.push('--env').push(params[:env]) unless params[:env].nil?
         command.push('--name').push(params[:name]) unless params[:name].nil?
-        command.push('--url').push(params[:url]) unless params[:url].nil?
+        # command.push('--url').push(params[:url]) unless params[:url].nil?
         command.push('--started').push(params[:started]) unless params[:started].nil?
         command.push('--finished').push(params[:time]) unless params[:finished].nil?
         command.push('--time').push(params[:time]) unless params[:time].nil?
@@ -49,27 +49,27 @@ module Fastlane
                                        description: "Release version to accociate the deloy with on Sentry"),
           FastlaneCore::ConfigItem.new(key: :env,
                                        short_option: "-e",
-                                       description: "Set the environment for this release. This argument is required. Values that make sense here would be 'production' or 'staging'.",
+                                       description: "Set the environment for this release. This argument is required. Values that make sense here would be 'production' or 'staging'",
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :name,
                                        short_option: "-n",
-                                       description: "Optional human readable name for this deployment.",
+                                       description: "Optional human readable name for this deployment",
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :url,
-                                       short_option: "-u",
-                                       description: "Optional URL that points to the deployment.",
-                                       optional: true),
+          # FastlaneCore::ConfigItem.new(key: :url,
+          #                              short_option: "-u",
+          #                              description: "Optional URL that points to the deployment",
+          #                              optional: true),
           FastlaneCore::ConfigItem.new(key: :started,
-                                       description: "Optional unix timestamp when the deployment started.",
+                                       description: "Optional unix timestamp when the deployment started",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :finished,
-                                       description: "Optional unix timestamp when the deployment finished.",
+                                       description: "Optional unix timestamp when the deployment finished",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :time,
                                        short_option: "-t",
-                                       description: "Optional deployment duration in seconds. This can be specified alternatively to `--started` and `--finished`.",
+                                       description: "Optional deployment duration in seconds. This can be specified alternatively to `--started` and `--finished`",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :app_identifier,

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -74,7 +74,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",
                                        env_name: "SENTRY_APP_IDENTIFIER",
-                                       description: "App Bundle Identifier, prepended to version",
+                                       description: "App Bundle Identifier, prepended with the version.\nFor example bundle@version",
                                        optional: true)
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -68,7 +68,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :time,
                                        short_option: "-t",
-                                       description: "Optional deployment duration in seconds. This can be specified alternatively to `--started` and `--finished`",
+                                       description: "Optional deployment duration in seconds. This can be specified alternatively to `started` and `finished`",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :app_identifier,

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -1,0 +1,31 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "create deploy" do
+      it "accepts app_identifier" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "app.idf@1.0", "new", "--env", "staging"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              app_identifier: 'app.idf',
+              env: 'staging')
+        end").runner.execute(:test)
+      end
+
+      it "does not prepend app_identifier if not specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging')
+        end").runner.execute(:test)
+      end
+    end
+  end
+end

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -82,13 +82,13 @@ describe Fastlane do
       it "includes --time if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 9001]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_create_deploy(
               version: '1.0',
               env: 'staging',
-              time: 9001)
+              time: 180)
         end").runner.execute(:test)
       end
     end

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -26,6 +26,58 @@ describe Fastlane do
               env: 'staging')
         end").runner.execute(:test)
       end
+
+      it "includes --name if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--name", "fixture-name"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              name: 'fixture-name')
+        end").runner.execute(:test)
+      end
+
+      it "includes --started if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--started", 1622630647]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              started: 1622630647)
+        end").runner.execute(:test)
+      end
+
+      it "includes --finished if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--finished", 1622630700]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              finished: 1622630700)
+        end").runner.execute(:test)
+      end
+
+      it "includes --time if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 9001]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              time: 9001)
+        end").runner.execute(:test)
+      end
     end
   end
 end

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -40,6 +40,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --url if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--url", "www.sentry.io"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              deploy_url: 'www.sentry.io')
+        end").runner.execute(:test)
+      end
+
       it "includes --started if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -43,13 +43,13 @@ describe Fastlane do
       it "includes --url if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--url", "www.sentry.io"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--url", "http://www.sentry.io"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_create_deploy(
               version: '1.0',
               env: 'staging',
-              deploy_url: 'www.sentry.io')
+              deploy_url: 'http://www.sentry.io')
         end").runner.execute(:test)
       end
 

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -89,7 +89,7 @@ describe Fastlane do
         end.to raise_error("Only one parmeter of 'started' and 'finished' found, please provide both.")
       end
 
-      it "omit --finished and --started if time if present" do
+      it "omit --started and --finished if time if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
@@ -100,6 +100,34 @@ describe Fastlane do
               env: 'staging',
               time: 180,
               started: 1622630647,
+              finished: 1622630700)
+        end").runner.execute(:test)
+      end
+
+      it "omit --started if time if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              time: 180,
+              started: 1622630647)
+        end").runner.execute(:test)
+      end
+
+      it "omit --finished if time if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              time: 180,
               finished: 1622630700)
         end").runner.execute(:test)
       end

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -67,58 +67,33 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "fails if started present without finished" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-              sentry_create_deploy(
-                version: '1.0',
-                env: 'staging',
-                started: 1622630647)
-          end").runner.execute(:test)
-        end.to raise_error("Only one parmeter of 'started' and 'finished' found, please provide both.")
-      end
-
-      it "fails if finished present without started" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-              sentry_create_deploy(
-                version: '1.0',
-                env: 'staging',
-                finished: 1622630700)
-          end").runner.execute(:test)
-        end.to raise_error("Only one parmeter of 'started' and 'finished' found, please provide both.")
-      end
-
-      it "omit --started and --finished if time if present" do
+      it "includes --started if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--started", 1622630647]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_create_deploy(
               version: '1.0',
               env: 'staging',
-              time: 180,
-              started: 1622630647,
-              finished: 1622630700)
-        end").runner.execute(:test)
-      end
-
-      it "omit --started if time if present" do
-        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
-        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
-
-        Fastlane::FastFile.new.parse("lane :test do
-            sentry_create_deploy(
-              version: '1.0',
-              env: 'staging',
-              time: 180,
               started: 1622630647)
         end").runner.execute(:test)
       end
 
-      it "omit --finished if time if present" do
+      it "includes --finished if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--finished", 1622630700]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              env: 'staging',
+              finished: 1622630700)
+        end").runner.execute(:test)
+      end
+
+      it "includes --time if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
@@ -127,8 +102,7 @@ describe Fastlane do
             sentry_create_deploy(
               version: '1.0',
               env: 'staging',
-              time: 180,
-              finished: 1622630700)
+              time: 180)
         end").runner.execute(:test)
       end
     end

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -53,33 +53,43 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "includes --started if present" do
+      it "includes --started and --finished if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--started", 1622630647]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--started", 1622630647, "--finished", 1622630700]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_create_deploy(
               version: '1.0',
               env: 'staging',
-              started: 1622630647)
-        end").runner.execute(:test)
-      end
-
-      it "includes --finished if present" do
-        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
-        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--finished", 1622630700]).and_return(true)
-
-        Fastlane::FastFile.new.parse("lane :test do
-            sentry_create_deploy(
-              version: '1.0',
-              env: 'staging',
+              started: 1622630647,
               finished: 1622630700)
         end").runner.execute(:test)
       end
 
-      it "includes --time if present" do
+      it "fails if started present without finished" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+              sentry_create_deploy(
+                version: '1.0',
+                env: 'staging',
+                started: 1622630647)
+          end").runner.execute(:test)
+        end.to raise_error("Only one parmeter of 'started' and 'finished' found, please provide both.")
+      end
+
+      it "fails if finished present without started" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+              sentry_create_deploy(
+                version: '1.0',
+                env: 'staging',
+                finished: 1622630700)
+          end").runner.execute(:test)
+        end.to raise_error("Only one parmeter of 'started' and 'finished' found, please provide both.")
+      end
+
+      it "omit --finished and --started if time if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0", "new", "--env", "staging", "--time", 180]).and_return(true)
@@ -88,7 +98,9 @@ describe Fastlane do
             sentry_create_deploy(
               version: '1.0',
               env: 'staging',
-              time: 180)
+              time: 180,
+              started: 1622630647,
+              finished: 1622630700)
         end").runner.execute(:test)
       end
     end


### PR DESCRIPTION
# Overview

- Introduce `sentry_create_deploy` action.
- The `url` parameter of the `sentry-cli` command is named `deploy_url` in the action, as it collides with another param.

# Testing

- Created `rspec` tests similar to other actions, mainly testing the parameters and how they translate to `sentry-cli` parameters.
- Tested with an iOS application that has sentry setup and created deploys with the param combinations. Could not see more info for deploys in `senty.io` though, is this a permissions/account "issue"?

<img width="433" alt="Bildschirmfoto 2021-06-02 um 15 49 57" src="https://user-images.githubusercontent.com/3984453/120494047-c23cd780-c3bb-11eb-9993-6964b369e3d5.png">

Relates to #82 