### PR TITLE
feat: Add sentry-cli upload-dif action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vnext
+
+- feat: upload-dif actions (#)
+
 ## 1.8.2
 
 - feat: Sentry Create Deploy Action (#83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add sentry-cli upload-dif action ([#89](https://github.com/getsentry/sentry-fastlane-plugin/pull/90))
+- Add sentry-cli upload-dif action ([#89](https://github.com/getsentry/sentry-fastlane-plugin/pull/89))
 
 
 ## 1.8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vnext
 
-- feat: upload-dif actions (#)
+- feat: Add sentry-cli upload-dif action (#89)
 
 ## 1.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 - Print sentry-cli level debug when verbose is set ([#88](https://github.com/getsentry/sentry-fastlane-plugin/pull/88))
 - Fix action to allow stripping prefix ([#87](https://github.com/getsentry/sentry-fastlane-plugin/pull/87))
->>>>>>> master
 
 ## 1.8.2
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,20 @@ sentry_upload_proguard(
   auth_token: '...', # Do not use if using api_key
   org_slug: '...',
   project_slug: '...',
-  android_manifest_path: 'path to merged AndroidManifest file' # found in `app/build/intermediates/manifests/full`
+  android_manifest_path: 'path to merged AndroidManifest file', # found in `app/build/intermediates/manifests/full`
   mapping_path: 'path to mapping.txt to upload',
+)
+```
+
+#### Upload Debugging Information Files
+
+```ruby
+sentry_upload_dif(
+  api_key: '...', # Do not use if using auth_token
+  auth_token: '...', # Do not use if using api_key
+  org_slug: '...',
+  project_slug: '...',
+  path: '/path/to/files'
 )
 ```
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,9 +7,6 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        # ids
-        # require_all
-        # symbol_maps
         # derived_data
         # no_zips
         # info_plist
@@ -29,6 +26,9 @@ module Fastlane
         command.push('--no_debug') unless params[:no_debug].nil?
         command.push('--no_sources') unless params[:no_sources].nil?
         command.push('--ids').push(params[:ids]) unless params[:ids].nil?
+        command.push('--require_all') unless params[:require_all].nil?
+        command.push('--symbol_maps').push(params[:symbol_maps]) unless params[:symbol_maps].nil?
+        command.push('--derived_data') unless params[:derived_data].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -87,26 +87,21 @@ module Fastlane
                                        optional: true),
             FastlaneCore::ConfigItem.new(key: :ids,
                                        description: "Search for specific debug identifiers",
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :require_all,
+                                       description: "Errors if not all identifiers specified with --id could be found",
                                        is_string: false,
                                        optional: true),
-          # FastlaneCore::ConfigItem.new(key: :started,
-          #                              description: "Optional unix timestamp when the deployment started",
-          #                              is_string: false,
-          #                              optional: true),
-          # FastlaneCore::ConfigItem.new(key: :finished,
-          #                              description: "Optional unix timestamp when the deployment finished",
-          #                              is_string: false,
-          #                              optional: true),
-          # FastlaneCore::ConfigItem.new(key: :time,
-          #                              short_option: "-t",
-          #                              description: "Optional deployment duration in seconds. This can be specified alternatively to `started` and `finished`",
-          #                              is_string: false,
-          #                              optional: true),
-          # FastlaneCore::ConfigItem.new(key: :app_identifier,
-          #                              short_option: "-a",
-          #                              env_name: "SENTRY_APP_IDENTIFIER",
-          #                              description: "App Bundle Identifier, prepended with the version.\nFor example bundle@version",
-          #                              optional: true)
+            FastlaneCore::ConfigItem.new(key: :symbol_maps,
+                                       description: "Optional path to BCSymbolMap files which are used to \
+                                       resolve hidden symbols in dSYM files downloaded from \
+                                       iTunes Connect. This requires the dsymutil tool to be \
+                                       available",
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :derived_data,
+                                       description: "Search for debug symbols in Xcode's derived data",
+                                       is_string: false,
+                                       optional: true),
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,9 +7,6 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        # paths
-        # types
-        # no_unwind
         # no_debug
         # no_sources
         # ids
@@ -29,6 +26,8 @@ module Fastlane
           "upload-dif"
         ]
         command.push('--paths').push(params[:paths]) unless params[:paths].nil?
+        command.push('--types').push(params[:types]) unless params[:types].nil?
+        command.push('--no_unwind') unless params[:no_unwind].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -53,13 +52,23 @@ module Fastlane
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :paths,
                                        description: "A path to search recursively for symbol files"),
-          # FastlaneCore::ConfigItem.new(key: :name,
-          #                              short_option: "-n",
-          #                              description: "Optional human readable name for this deployment",
-          #                              optional: true),
-          # FastlaneCore::ConfigItem.new(key: :deploy_url,
-          #                              description: "Optional URL that points to the deployment",
-          #                              optional: true),
+          FastlaneCore::ConfigItem.new(key: :types,
+                                       short_option: "-t",
+                                       description: "Only consider debug information files of the given \
+                                       type.  By default, all types are considered",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                        UI.user_error! "Invalid value '#{value}'" unless ['dsym', 'elf', 'breakpad', 'pdb', 'pe', 'sourcebundle', 'bcsymbolmap'].include? value
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :no_unwind,
+                                       description: "Do not scan for stack unwinding information. Specify \
+                                       this flag for builds with disabled FPO, or when \
+                                       stackwalking occurs on the device. This usually \
+                                       excludes executables and dynamic libraries. They might \
+                                       still be uploaded, if they contain additional \
+                                       processable information (see other flags)",
+                                       is_string: false,
+                                       optional: true),
           # FastlaneCore::ConfigItem.new(key: :started,
           #                              description: "Optional unix timestamp when the deployment started",
           #                              is_string: false,

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -28,6 +28,7 @@ module Fastlane
         command.push('--paths').push(params[:paths]) unless params[:paths].nil?
         command.push('--types').push(params[:types]) unless params[:types].nil?
         command.push('--no_unwind') unless params[:no_unwind].nil?
+        command.push('--no_debug') unless params[:no_debug].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -65,6 +66,13 @@ module Fastlane
                                        this flag for builds with disabled FPO, or when \
                                        stackwalking occurs on the device. This usually \
                                        excludes executables and dynamic libraries. They might \
+                                       still be uploaded, if they contain additional \
+                                       processable information (see other flags)",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :no_debug,
+                                       description: "Do not scan for debugging information. This will \
+                                       usually exclude debug companion files. They might \
                                        still be uploaded, if they contain additional \
                                        processable information (see other flags)",
                                        is_string: false,

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,8 +7,6 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        # info_plist
-        # no_reprocessing
         # force_foreground
         # include_sources
         # wait
@@ -29,6 +27,7 @@ module Fastlane
         command.push('--derived_data') unless params[:derived_data].nil?
         command.push('--no_zips') unless params[:no_zips].nil?
         command.push('--info_plist').push(params[:info_plist]) unless params[:info_plist].nil?
+        command.push('--no_reprocessing') unless params[:no_reprocessing].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -112,6 +111,10 @@ module Fastlane
                                        will associate the debug symbols with a specific ITC application \
                                        and build in Sentry.  Note that if you provide the plist \
                                        explicitly it must already be processed",
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :no_reprocessing,
+                                       description: "Do not trigger reprocessing after uploading",
+                                       is_string: false,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -28,6 +28,7 @@ module Fastlane
         command.push('--symbol_maps').push(params[:symbol_maps]) unless params[:symbol_maps].nil?
         command.push('--derived_data') unless params[:derived_data].nil?
         command.push('--no_zips') unless params[:no_zips].nil?
+        command.push('--info_plist').push(params[:info_plist]) unless params[:info_plist].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -104,6 +105,13 @@ module Fastlane
             FastlaneCore::ConfigItem.new(key: :no_zips,
                                        description: "Do not search in ZIP files",
                                        is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :info_plist,
+                                       description: "Optional path to the Info.plist.{n}We will try to find this \
+                                       automatically if run from Xcode.  Providing this information \
+                                       will associate the debug symbols with a specific ITC application \
+                                       and build in Sentry.  Note that if you provide the plist \
+                                       explicitly it must already be processed",
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -1,0 +1,97 @@
+module Fastlane
+  module Actions
+    class SentryUploadDifAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryHelper.check_sentry_cli!
+        Helper::SentryConfig.parse_api_params(params)
+
+        # paths
+        # types
+        # no_unwind
+        # no_debug
+        # no_sources
+        # ids
+        # require_all
+        # symbol_maps
+        # derived_data
+        # no_zips
+        # info_plist
+        # no_reprocessing
+        # force_foreground
+        # include_sources
+        # wait
+        # upload_symbol_maps
+
+        command = [
+          "sentry-cli",
+          "upload-dif"
+        ]
+        command.push('--paths').push(params[:paths]) unless params[:paths].nil?
+
+        Helper::SentryHelper.call_sentry_cli(command)
+        UI.success("Successfully ran upload-dif")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload debugging information files."
+      end
+
+      def self.details
+        [
+          "Files can be uploaded using the upload-dif command. This command will scan a given folder recursively for files and upload them to Sentry.",
+          "See https://docs.sentry.io/platforms/native/data-management/debug-files/upload/ for more information."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :paths,
+                                       description: "A path to search recursively for symbol files"),
+          # FastlaneCore::ConfigItem.new(key: :name,
+          #                              short_option: "-n",
+          #                              description: "Optional human readable name for this deployment",
+          #                              optional: true),
+          # FastlaneCore::ConfigItem.new(key: :deploy_url,
+          #                              description: "Optional URL that points to the deployment",
+          #                              optional: true),
+          # FastlaneCore::ConfigItem.new(key: :started,
+          #                              description: "Optional unix timestamp when the deployment started",
+          #                              is_string: false,
+          #                              optional: true),
+          # FastlaneCore::ConfigItem.new(key: :finished,
+          #                              description: "Optional unix timestamp when the deployment finished",
+          #                              is_string: false,
+          #                              optional: true),
+          # FastlaneCore::ConfigItem.new(key: :time,
+          #                              short_option: "-t",
+          #                              description: "Optional deployment duration in seconds. This can be specified alternatively to `started` and `finished`",
+          #                              is_string: false,
+          #                              optional: true),
+          # FastlaneCore::ConfigItem.new(key: :app_identifier,
+          #                              short_option: "-a",
+          #                              env_name: "SENTRY_APP_IDENTIFIER",
+          #                              description: "App Bundle Identifier, prepended with the version.\nFor example bundle@version",
+          #                              optional: true)
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["denrase"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,8 +7,6 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        # derived_data
-        # no_zips
         # info_plist
         # no_reprocessing
         # force_foreground
@@ -29,6 +27,7 @@ module Fastlane
         command.push('--require_all') unless params[:require_all].nil?
         command.push('--symbol_maps').push(params[:symbol_maps]) unless params[:symbol_maps].nil?
         command.push('--derived_data') unless params[:derived_data].nil?
+        command.push('--no_zips') unless params[:no_zips].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -100,6 +99,10 @@ module Fastlane
                                        optional: true),
             FastlaneCore::ConfigItem.new(key: :derived_data,
                                        description: "Search for debug symbols in Xcode's derived data",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :no_zips,
+                                       description: "Do not search in ZIP files",
                                        is_string: false,
                                        optional: true),
         ]

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -28,6 +28,7 @@ module Fastlane
         command.push('--no_zips') unless params[:no_zips].nil?
         command.push('--info_plist').push(params[:info_plist]) unless params[:info_plist].nil?
         command.push('--no_reprocessing') unless params[:no_reprocessing].nil?
+        command.push('--force_foreground') unless params[:force_foreground].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -114,6 +115,15 @@ module Fastlane
                                        optional: true),
             FastlaneCore::ConfigItem.new(key: :no_reprocessing,
                                        description: "Do not trigger reprocessing after uploading",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :force_foreground,
+                                       description: "Wait for the process to finish.{n}\
+                                       By default, the upload process will detach and continue in the \
+                                       background when triggered from Xcode.  When an error happens, \
+                                       a dialog is shown.  If this parameter is passed Xcode will wait \
+                                       for the process to finish before the build finishes and output \
+                                       will be shown in the Xcode build output",
                                        is_string: false,
                                        optional: true),
         ]

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -11,8 +11,8 @@ module Fastlane
           "sentry-cli",
           "upload-dif"
         ]
-        command.push('--paths').push(params[:paths]) unless params[:paths].nil?
-        command.push('--types').push(params[:types]) unless params[:types].nil?
+        command.push('--path').push(params[:path]) unless params[:path].nil?
+        command.push('--type').push(params[:type]) unless params[:type].nil?
         command.push('--no_unwind') unless params[:no_unwind].nil?
         command.push('--no_debug') unless params[:no_debug].nil?
         command.push('--no_sources') unless params[:no_sources].nil?
@@ -43,15 +43,15 @@ module Fastlane
       def self.details
         [
           "Files can be uploaded using the upload-dif command. This command will scan a given folder recursively for files and upload them to Sentry.",
-          "See https://docs.sentry.io/platforms/native/data-management/debug-files/upload/ for more information."
+          "See https://docs.sentry.io/product/cli/dif/#uploading-files for more information."
         ].join(" ")
       end
 
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
-          FastlaneCore::ConfigItem.new(key: :paths,
+          FastlaneCore::ConfigItem.new(key: :path,
                                        description: "A path to search recursively for symbol files"),
-          FastlaneCore::ConfigItem.new(key: :types,
+          FastlaneCore::ConfigItem.new(key: :type,
                                        short_option: "-t",
                                        description: "Only consider debug information files of the given \
                                        type.  By default, all types are considered",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -28,7 +28,8 @@ module Fastlane
         command.push('--no_unwind') unless params[:no_unwind].nil?
         command.push('--no_debug') unless params[:no_debug].nil?
         command.push('--no_sources') unless params[:no_sources].nil?
-        
+        command.push('--ids').push(params[:ids]) unless params[:ids].nil?
+
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
       end
@@ -82,6 +83,10 @@ module Fastlane
                                        usually exclude source bundle files. They might \
                                        still be uploaded, if they contain additional \
                                        processable information (see other flags)",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :ids,
+                                       description: "Search for specific debug identifiers",
                                        is_string: false,
                                        optional: true),
           # FastlaneCore::ConfigItem.new(key: :started,

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,11 +7,13 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
+        path = params[:path]
+
         command = [
           "sentry-cli",
-          "upload-dif"
+          "upload-dif",
+          path
         ]
-        command.push('--path').push(params[:path]) unless params[:path].nil?
         command.push('--type').push(params[:type]) unless params[:type].nil?
         command.push('--no_unwind') unless params[:no_unwind].nil?
         command.push('--no_debug') unless params[:no_debug].nil?

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,11 +7,6 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        # force_foreground
-        # include_sources
-        # wait
-        # upload_symbol_maps
-
         command = [
           "sentry-cli",
           "upload-dif"
@@ -29,6 +24,9 @@ module Fastlane
         command.push('--info_plist').push(params[:info_plist]) unless params[:info_plist].nil?
         command.push('--no_reprocessing') unless params[:no_reprocessing].nil?
         command.push('--force_foreground') unless params[:force_foreground].nil?
+        command.push('--include_sources') unless params[:include_sources].nil?
+        command.push('--wait') unless params[:wait].nil?
+        command.push('--upload_symbol_maps') unless params[:upload_symbol_maps].nil?
 
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
@@ -124,6 +122,24 @@ module Fastlane
                                        a dialog is shown.  If this parameter is passed Xcode will wait \
                                        for the process to finish before the build finishes and output \
                                        will be shown in the Xcode build output",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :include_sources,
+                                       description: "Include sources from the local file system and upload \
+                                       them as source bundles",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :wait,
+                                       description: "Wait for the server to fully process uploaded files. Errors \
+                                       can only be displayed if --wait is specified, but this will \
+                                       significantly slow down the upload process",
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :upload_symbol_maps,
+                                       description: "Upload any BCSymbolMap files found to allow Sentry to resolve \
+                                       hidden symbols, e.g. when it downloads dSYMs directly from App \
+                                       Store Connect or when you upload dSYMs without first resolving \
+                                       the hidden symbols using --symbol-maps",
                                        is_string: false,
                                        optional: true),
         ]

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -7,8 +7,6 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        # no_debug
-        # no_sources
         # ids
         # require_all
         # symbol_maps
@@ -29,7 +27,8 @@ module Fastlane
         command.push('--types').push(params[:types]) unless params[:types].nil?
         command.push('--no_unwind') unless params[:no_unwind].nil?
         command.push('--no_debug') unless params[:no_debug].nil?
-
+        command.push('--no_sources') unless params[:no_sources].nil?
+        
         Helper::SentryHelper.call_sentry_cli(command)
         UI.success("Successfully ran upload-dif")
       end
@@ -73,6 +72,14 @@ module Fastlane
             FastlaneCore::ConfigItem.new(key: :no_debug,
                                        description: "Do not scan for debugging information. This will \
                                        usually exclude debug companion files. They might \
+                                       still be uploaded, if they contain additional \
+                                       processable information (see other flags)",
+                                       conflicting_options: [:no_unwind],
+                                       is_string: false,
+                                       optional: true),
+            FastlaneCore::ConfigItem.new(key: :no_sources,
+                                       description: "Do not scan for source information. This will \
+                                       usually exclude source bundle files. They might \
                                        still be uploaded, if they contain additional \
                                        processable information (see other flags)",
                                        is_string: false,

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -156,6 +156,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --ids if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--ids", "fixture-ids"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              ids: 'fixture-ids'
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -143,6 +143,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --no_sources when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_sources"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              no_sources: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -234,5 +234,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
     end
+
+    it "includes --no_reprocessing when true" do
+      expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+      expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+      expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_reprocessing"]).and_return(true)
+
+      Fastlane::FastFile.new.parse("lane :test do
+          sentry_upload_dif(
+            paths: 'fixture-paths',
+            no_reprocessing: true
+          )
+      end").runner.execute(:test)
+    end
+
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -1,0 +1,17 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "upload-dif" do
+      it "includes --path if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths'
+            )
+        end").runner.execute(:test)
+      end
+    end
+  end
+end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -221,6 +221,18 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --info_plist if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--info_plist", "fixture-info_plist"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              info_plist: 'fixture-info_plist'
+            )
+        end").runner.execute(:test)
+      end
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -4,114 +4,114 @@ describe Fastlane do
       it "includes --path if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths'
+              path: 'fixture-path'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value dsym" do
+      it "includes --type for value dsym" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "dsym"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "dsym"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'dsym'
+              path: 'fixture-path',
+              type: 'dsym'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value elf" do
+      it "includes --type for value elf" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "elf"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "elf"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'elf'
+              path: 'fixture-path',
+              type: 'elf'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value breakpad" do
+      it "includes --type for value breakpad" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "breakpad"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "breakpad"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'breakpad'
+              path: 'fixture-path',
+              type: 'breakpad'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value pdb" do
+      it "includes --type for value pdb" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "pdb"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "pdb"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'pdb'
+              path: 'fixture-path',
+              type: 'pdb'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value pe" do
+      it "includes --type for value pe" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "pe"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "pe"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'pe'
+              path: 'fixture-path',
+              type: 'pe'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value sourcebundle" do
+      it "includes --type for value sourcebundle" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "sourcebundle"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "sourcebundle"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'sourcebundle'
+              path: 'fixture-path',
+              type: 'sourcebundle'
             )
         end").runner.execute(:test)
       end
 
-      it "includes --types for value bcsymbolmap" do
+      it "includes --type for value bcsymbolmap" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "bcsymbolmap"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "bcsymbolmap"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
-              types: 'bcsymbolmap'
+              path: 'fixture-path',
+              type: 'bcsymbolmap'
             )
         end").runner.execute(:test)
       end
 
-      it "fails with unknown --types value" do
+      it "fails with unknown --type value" do
         dsym_path_1 = File.absolute_path './assets/this_does_not_exist.app.dSYM.zip'
 
         expect do
           Fastlane::FastFile.new.parse("lane :test do
               sentry_upload_dif(
-                paths: 'fixture-paths',
-                types: 'unknown'
+                path: 'fixture-path',
+                type: 'unknown'
               )
           end").runner.execute(:test)
         end.to raise_error("Invalid value 'unknown'")
@@ -120,11 +120,11 @@ describe Fastlane do
       it "includes --no_unwind when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_unwind"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_unwind"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               no_unwind: true
             )
         end").runner.execute(:test)
@@ -133,11 +133,11 @@ describe Fastlane do
       it "includes --no_debug when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_debug"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_debug"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               no_debug: true
             )
         end").runner.execute(:test)
@@ -146,11 +146,11 @@ describe Fastlane do
       it "includes --no_sources when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_sources"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_sources"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               no_sources: true
             )
         end").runner.execute(:test)
@@ -159,11 +159,11 @@ describe Fastlane do
       it "includes --ids if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--ids", "fixture-ids"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--ids", "fixture-ids"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               ids: 'fixture-ids'
             )
         end").runner.execute(:test)
@@ -172,11 +172,11 @@ describe Fastlane do
       it "includes --require_all when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--require_all"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--require_all"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               require_all: true
             )
         end").runner.execute(:test)
@@ -185,11 +185,11 @@ describe Fastlane do
       it "includes --symbol_maps if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--symbol_maps", "fixture-symbol_maps"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--symbol_maps", "fixture-symbol_maps"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               symbol_maps: 'fixture-symbol_maps'
             )
         end").runner.execute(:test)
@@ -198,11 +198,11 @@ describe Fastlane do
       it "includes --derived_data when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--derived_data"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--derived_data"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               derived_data: true
             )
         end").runner.execute(:test)
@@ -211,11 +211,11 @@ describe Fastlane do
       it "includes --no_zips when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_zips"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_zips"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               no_zips: true
             )
         end").runner.execute(:test)
@@ -224,11 +224,11 @@ describe Fastlane do
       it "includes --info_plist if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--info_plist", "fixture-info_plist"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--info_plist", "fixture-info_plist"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               info_plist: 'fixture-info_plist'
             )
         end").runner.execute(:test)
@@ -237,11 +237,11 @@ describe Fastlane do
       it "includes --no_reprocessing when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_reprocessing"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_reprocessing"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               no_reprocessing: true
             )
         end").runner.execute(:test)
@@ -250,11 +250,11 @@ describe Fastlane do
       it "includes --force_foreground when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--force_foreground"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--force_foreground"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               force_foreground: true
             )
         end").runner.execute(:test)
@@ -263,11 +263,11 @@ describe Fastlane do
       it "includes --include_sources when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--include_sources"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--include_sources"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               include_sources: true
             )
         end").runner.execute(:test)
@@ -276,11 +276,11 @@ describe Fastlane do
       it "includes --wait when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--wait"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--wait"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               wait: true
             )
         end").runner.execute(:test)
@@ -289,11 +289,11 @@ describe Fastlane do
       it "includes --upload_symbol_maps when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--upload_symbol_maps"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--upload_symbol_maps"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              paths: 'fixture-paths',
+              path: 'fixture-path',
               upload_symbol_maps: true
             )
         end").runner.execute(:test)

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -208,6 +208,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --no_zips when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_zips"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              no_zips: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -12,6 +12,124 @@ describe Fastlane do
             )
         end").runner.execute(:test)
       end
+
+      it "includes --types for value dsym" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "dsym"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'dsym'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --types for value elf" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "elf"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'elf'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --types for value breakpad" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "breakpad"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'breakpad'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --types for value pdb" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "pdb"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'pdb'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --types for value pe" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "pe"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'pe'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --types for value sourcebundle" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "sourcebundle"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'sourcebundle'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --types for value bcsymbolmap" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--types", "bcsymbolmap"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              types: 'bcsymbolmap'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "fails with unknown --types value" do
+        dsym_path_1 = File.absolute_path './assets/this_does_not_exist.app.dSYM.zip'
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+              sentry_upload_dif(
+                paths: 'fixture-paths',
+                types: 'unknown'
+              )
+          end").runner.execute(:test)
+        end.to raise_error("Invalid value 'unknown'")
+      end
+
+      it "includes --no_unwind when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_unwind"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              no_unwind: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -260,6 +260,45 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --include_sources when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--include_sources"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              include_sources: true
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --wait when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--wait"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              wait: true
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --upload_symbol_maps when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--upload_symbol_maps"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              upload_symbol_maps: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -130,6 +130,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --no_debug when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_debug"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              no_debug: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -169,6 +169,45 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "includes --require_all when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--require_all"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              require_all: true
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --symbol_maps if present" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--symbol_maps", "fixture-symbol_maps"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              symbol_maps: 'fixture-symbol_maps'
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --derived_data when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--derived_data"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              derived_data: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -233,20 +233,33 @@ describe Fastlane do
             )
         end").runner.execute(:test)
       end
+
+      it "includes --no_reprocessing when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_reprocessing"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              no_reprocessing: true
+            )
+        end").runner.execute(:test)
+      end
+
+      it "includes --force_foreground when true" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--force_foreground"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              paths: 'fixture-paths',
+              force_foreground: true
+            )
+        end").runner.execute(:test)
+      end
+
     end
-
-    it "includes --no_reprocessing when true" do
-      expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
-      expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-      expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--paths", "fixture-paths", "--no_reprocessing"]).and_return(true)
-
-      Fastlane::FastFile.new.parse("lane :test do
-          sentry_upload_dif(
-            paths: 'fixture-paths',
-            no_reprocessing: true
-          )
-      end").runner.execute(:test)
-    end
-
   end
 end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -4,7 +4,7 @@ describe Fastlane do
       it "includes --path if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -16,7 +16,7 @@ describe Fastlane do
       it "includes --type for value dsym" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "dsym"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "dsym"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -29,7 +29,7 @@ describe Fastlane do
       it "includes --type for value elf" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "elf"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "elf"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -42,7 +42,7 @@ describe Fastlane do
       it "includes --type for value breakpad" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "breakpad"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "breakpad"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -55,7 +55,7 @@ describe Fastlane do
       it "includes --type for value pdb" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "pdb"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "pdb"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -68,7 +68,7 @@ describe Fastlane do
       it "includes --type for value pe" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "pe"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "pe"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -81,7 +81,7 @@ describe Fastlane do
       it "includes --type for value sourcebundle" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "sourcebundle"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "sourcebundle"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -94,7 +94,7 @@ describe Fastlane do
       it "includes --type for value bcsymbolmap" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--type", "bcsymbolmap"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--type", "bcsymbolmap"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -120,7 +120,7 @@ describe Fastlane do
       it "includes --no_unwind when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_unwind"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--no_unwind"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -133,7 +133,7 @@ describe Fastlane do
       it "includes --no_debug when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_debug"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--no_debug"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -146,7 +146,7 @@ describe Fastlane do
       it "includes --no_sources when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_sources"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--no_sources"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -159,7 +159,7 @@ describe Fastlane do
       it "includes --ids if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--ids", "fixture-ids"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--ids", "fixture-ids"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -172,7 +172,7 @@ describe Fastlane do
       it "includes --require_all when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--require_all"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--require_all"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -185,7 +185,7 @@ describe Fastlane do
       it "includes --symbol_maps if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--symbol_maps", "fixture-symbol_maps"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--symbol_maps", "fixture-symbol_maps"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -198,7 +198,7 @@ describe Fastlane do
       it "includes --derived_data when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--derived_data"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--derived_data"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -211,7 +211,7 @@ describe Fastlane do
       it "includes --no_zips when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_zips"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--no_zips"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -224,7 +224,7 @@ describe Fastlane do
       it "includes --info_plist if present" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--info_plist", "fixture-info_plist"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--info_plist", "fixture-info_plist"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -237,7 +237,7 @@ describe Fastlane do
       it "includes --no_reprocessing when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--no_reprocessing"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--no_reprocessing"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -250,7 +250,7 @@ describe Fastlane do
       it "includes --force_foreground when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--force_foreground"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--force_foreground"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -263,7 +263,7 @@ describe Fastlane do
       it "includes --include_sources when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--include_sources"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--include_sources"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -276,7 +276,7 @@ describe Fastlane do
       it "includes --wait when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--wait"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--wait"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
@@ -289,7 +289,7 @@ describe Fastlane do
       it "includes --upload_symbol_maps when true" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "--path", "fixture-path", "--upload_symbol_maps"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "upload-dif", "fixture-path", "--upload_symbol_maps"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(


### PR DESCRIPTION
# Overview

- Introduce `sentry_upload_dif` action.

# Testing

- Created `rspec` tests, testing the parameters and how they translate to `sentry-cli` parameters.
- Tested with an iOS application that has sentry setup to upload dsym files using `upload-dif` action.

Relates to #86