### PR TITLE
feat: Support build numbers in versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vnext
+
+- feat: Support build numbers in versions (#90)
+
 ## 1.8.2
 
 - feat: Sentry Create Deploy Action (#83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-- feat: Support build numbers in versions (#90)
+- Support build numbers in versions ([#90](https://github.com/getsentry/sentry-fastlane-plugin/pull/90))
+
 
 ## 1.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 - Print sentry-cli level debug when verbose is set ([#88](https://github.com/getsentry/sentry-fastlane-plugin/pull/88))
 - Fix action to allow stripping prefix ([#87](https://github.com/getsentry/sentry-fastlane-plugin/pull/87))
->>>>>>> master
 
 ## 1.8.2
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ sentry_upload_file(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
+  build: '...', # Optionally pass in the build number of your app
   dist: '...', # optional distribution of the release usually the buildnumber
   file: 'main.jsbundle' # file to upload
 )
@@ -85,6 +86,7 @@ sentry_upload_sourcemap(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
+  build: '...', # Optionally pass in the build number of your app
   dist: '...', # optional distribution of the release usually the buildnumber
   sourcemap: 'main.jsbundle.map', # sourcemap to upload
   rewrite: true
@@ -112,6 +114,7 @@ Useful for telling Sentry which commits are associated with a release.
 sentry_set_commits(
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
+  build: '...', # Optionally pass in the build number of your app
   auto: false, # enable completely automated commit management
   clear: false, # clear all current commits from the release
   commit: '...', # commit spec, see `sentry-cli releases help set-commits` for more information
@@ -130,6 +133,7 @@ sentry_create_deploy(
   project_slug: '...',
   version: '...',
   app_identifier: '...', # pass in the bundle_identifer of your app
+  build: '...', # Optionally pass in the build number of your app
   env: 'staging', # The environment for this deploy. Required.
   name: '...', # Optional human readable name
   deploy_url: '...', # Optional URL that points to the deployment

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_deploy.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        version = "#{version}+#{params[:build]}" if params[:build]
 
         command = [
           "sentry-cli",
@@ -47,6 +48,15 @@ module Fastlane
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version to associate the deploy with on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                       short_option: "-a",
+                                       env_name: "SENTRY_APP_IDENTIFIER",
+                                       description: "App Bundle Identifier, prepended with the version.\nFor example bundle@version",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :build,
+                                       short_option: "-b",
+                                       description: "Release build to associate the deploy with on Sentry",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :env,
                                        short_option: "-e",
                                        description: "Set the environment for this release. This argument is required. Values that make sense here would be 'production' or 'staging'",
@@ -70,11 +80,6 @@ module Fastlane
                                        short_option: "-t",
                                        description: "Optional deployment duration in seconds. This can be specified alternatively to `started` and `finished`",
                                        is_string: false,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :app_identifier,
-                                       short_option: "-a",
-                                       env_name: "SENTRY_APP_IDENTIFIER",
-                                       description: "App Bundle Identifier, prepended with the version.\nFor example bundle@version",
                                        optional: true)
         ]
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_create_release.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        version = "#{version}+#{params[:build]}" if params[:build]
 
         command = [
           "sentry-cli",
@@ -41,17 +42,20 @@ module Fastlane
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version to create on Sentry"),
-          FastlaneCore::ConfigItem.new(key: :finalize,
-                                       description: "Whether to finalize the release. If not provided or false, the release can be finalized using the finalize_release action",
-                                       default_value: false,
-                                       is_string: false,
-                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
                                       description: "App Bundle Identifier, prepended to version",
-                                      optional: true)
-
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :build,
+                                      short_option: "-b",
+                                      description: "Release build to create on Sentry",
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :finalize,
+                                       description: "Whether to finalize the release. If not provided or false, the release can be finalized using the finalize_release action",
+                                       default_value: false,
+                                       is_string: false,
+                                       optional: true)
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_finalize_release.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        version = "#{version}+#{params[:build]}" if params[:build]
 
         command = [
           "sentry-cli",
@@ -44,8 +45,11 @@ module Fastlane
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
                                       description: "App Bundle Identifier, prepended to version",
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :build,
+                                      short_option: "-b",
+                                      description: "Release build to finalize on Sentry",
                                       optional: true)
-
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        version = "#{version}+#{params[:build]}" if params[:build]
 
         command = [
           "sentry-cli",
@@ -48,6 +49,10 @@ module Fastlane
                                       short_option: "-a",
                                       env_name: "SENTRY_APP_IDENTIFIER",
                                       description: "App Bundle Identifier, prepended to version",
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :build,
+                                      short_option: "-b",
+                                      description: "Release build on Sentry",
                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :auto,
                                       description: "Enable completely automated commit management",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_file.rb
@@ -7,10 +7,11 @@ module Fastlane
         Helper::SentryHelper.check_sentry_cli!
         Helper::SentryConfig.parse_api_params(params)
 
-        file = params[:file]
-
         version = params[:version]
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        version = "#{version}+#{params[:build]}" if params[:build]
+
+        file = params[:file]
 
         command = [
           "sentry-cli",
@@ -46,6 +47,15 @@ module Fastlane
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                      short_option: "-a",
+                                      env_name: "SENTRY_APP_IDENTIFIER",
+                                      description: "App Bundle Identifier, prepended to version",
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :build,
+                                      short_option: "-b",
+                                      description: "Release build on Sentry",
+                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :dist,
                                        description: "Distribution in release",
                                        optional: true),
@@ -56,12 +66,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :file_url,
                                        description: "Optional URL we should associate with the file",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :app_identifier,
-                                      short_option: "-a",
-                                      env_name: "SENTRY_APP_IDENTIFIER",
-                                      description: "App Bundle Identifier, prepended to version",
-                                      optional: true)
+                                       optional: true)
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -8,9 +8,10 @@ module Fastlane
         Helper::SentryConfig.parse_api_params(params)
 
         version = params[:version]
-        sourcemap = params[:sourcemap]
-
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
+        version = "#{version}+#{params[:build]}" if params[:build]
+
+        sourcemap = params[:sourcemap]
 
         command = [
           "sentry-cli",
@@ -63,6 +64,15 @@ module Fastlane
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "Release version on Sentry"),
+          FastlaneCore::ConfigItem.new(key: :app_identifier,
+                                       short_option: "-a",
+                                       env_name: "SENTRY_APP_IDENTIFIER",
+                                       description: "App Bundle Identifier, prepended to version",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :build,
+                                      short_option: "-b",
+                                      description: "Release build on Sentry",
+                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :dist,
                                        description: "Distribution in release",
                                        optional: true),
@@ -90,11 +100,6 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :url_prefix,
                                        description: "Sets a URL prefix in front of all files",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :app_identifier,
-                                       short_option: "-a",
-                                       env_name: "SENTRY_APP_IDENTIFIER",
-                                       description: "App Bundle Identifier, prepended to version",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ignore,
                                        description: "Ignores all files and folders matching the given glob or array of globs",

--- a/spec/sentry_create_deploy_spec.rb
+++ b/spec/sentry_create_deploy_spec.rb
@@ -15,6 +15,20 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "accepts build" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "deploys", "1.0+123", "new", "--env", "staging"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_create_deploy(
+              version: '1.0',
+              build: '123',
+              env: 'staging')
+        end").runner.execute(:test)
+      end
+
       it "does not prepend app_identifier if not specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)

--- a/spec/sentry_finalize_release_spec.rb
+++ b/spec/sentry_finalize_release_spec.rb
@@ -1,14 +1,14 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "create release" do
+    describe "finalize release" do
       it "accepts app_identifier" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "app.idf@1.0"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "finalize", "app.idf@1.0"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
-            sentry_create_release(
+            sentry_finalize_release(
               version: '1.0',
               app_identifier: 'app.idf')
         end").runner.execute(:test)
@@ -18,10 +18,10 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "1.0+123"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "finalize", "1.0+123"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
-            sentry_create_release(
+            sentry_finalize_release(
               version: '1.0',
               build: '123')
         end").runner.execute(:test)
@@ -30,10 +30,10 @@ describe Fastlane do
       it "does not prepend app_identifier if not specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "new", "1.0"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "finalize", "1.0"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
-            sentry_create_release(
+            sentry_finalize_release(
               version: '1.0')
         end").runner.execute(:test)
       end

--- a/spec/sentry_set_commits_spec.rb
+++ b/spec/sentry_set_commits_spec.rb
@@ -14,6 +14,19 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "accepts build" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "set-commits", "1.0+123"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_set_commits(
+              version: '1.0',
+              build: '123')
+        end").runner.execute(:test)
+      end
+
       it "does not prepend app_identifier if not specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)

--- a/spec/sentry_upload_file_spec.rb
+++ b/spec/sentry_upload_file_spec.rb
@@ -54,6 +54,27 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "accepts build" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "1.0+123", "upload", "demo.file", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("demo.file").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_file(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              file: 'demo.file',
+              build: '123')
+        end").runner.execute(:test)
+      end
+
       it "does not prepend app_identifier if not specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -54,6 +54,27 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "accepts build" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "1.0+123", "upload-sourcemaps", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              sourcemap: '1.map',
+              build: '123')
+        end").runner.execute(:test)
+      end
+
       it "does not prepend app_identifier if not specified" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)


### PR DESCRIPTION
# Overview

- Adds `build` parameter for actions that also take `version` and `app_identifier`
- Build is appended to previous version string, superseded by a `+` character: `app_identifier@version+build`

Closes #84 