### PR TITLE
fix: (upload-sourcemaps) - don't push value to non-value param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add sentry-cli upload-dif action ([#89](https://github.com/getsentry/sentry-fastlane-plugin/pull/89))
 - Support build numbers in versions ([#90](https://github.com/getsentry/sentry-fastlane-plugin/pull/90))
-
+- Don't push value to non-value param for upload-sourcemaps ([#92](https://github.com/getsentry/sentry-fastlane-plugin/pull/92))
 
 ## 1.8.3
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -25,7 +25,7 @@ module Fastlane
         command.push('--rewrite') if params[:rewrite]
         command.push('--no-rewrite') unless params[:rewrite]
         command.push('--strip-prefix').push(params[:strip_prefix]) if params[:strip_prefix]
-        command.push('--strip-common-prefix').push(params[:strip_common_prefix]) if params[:strip_common_prefix]
+        command.push('--strip-common-prefix') if params[:strip_common_prefix]
         command.push('--url-prefix').push(params[:url_prefix]) unless params[:url_prefix].nil?
         command.push('--dist').push(params[:dist]) unless params[:dist].nil?
 

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -98,11 +98,11 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "uses input value for strip_common_prefix" do
+      it "accepts strip_common_prefix" do
         expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.map", "--no-rewrite","--strip-common-prefix", "/Users/get-sentry/semtry-fastlane-plugin", "--dist", "dem"]).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.map", "--no-rewrite","--strip-common-prefix", "--dist", "dem"]).and_return(true)
 
         allow(File).to receive(:exist?).and_call_original
         expect(File).to receive(:exist?).with("1.map").and_return(true)
@@ -115,8 +115,28 @@ describe Fastlane do
               version: '1.0',
               dist: 'dem',
               sourcemap: '1.map',
-              app_identifier: 'app.idf',
-              strip_common_prefix: '/Users/get-sentry/semtry-fastlane-plugin',
+              strip_common_prefix: true,
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
+      it "does not prepend strip_common_prefix if not specified" do
+        expect(Fastlane::Helper::SentryHelper).to receive(:check_sentry_cli!).and_return(true)
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(["sentry-cli", "releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              sourcemap: '1.map',
               app_identifier: 'app.idf')
         end").runner.execute(:test)
       end


### PR DESCRIPTION
```
        --strip-common-prefix
            Similar to --strip-prefix but strips the most common prefix on all sources references.

        --strip-prefix <PREFIX>...
            Strips the given prefix from all sources references inside the upload sourcemaps (paths
            used within the sourcemap content, to map minified code to it's original source). Only
            sources that start with the given prefix will be stripped.
            This will not modify the uploaded sources paths. To do that, point the upload or upload-
            sourcemaps command to a more precise directory instead.
```

A regression occurred here - https://github.com/getsentry/sentry-fastlane-plugin/commit/1ca8217d8b1283efc6a3d34cead6fbc4db52de65 where it assumed that `--strip-common-prefix` acts like `--strip-prefix`, but it does not. It is a flag that is either included or not. It does not take a value.

I've updated the test and added a regression test.

Originally reported here - https://github.com/getsentry/sentry-cli/issues/1002