### PR TITLE
ci: Use Dangerfile of sentry-cocoa

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,47 +1,43 @@
-const PR_LINK = `([#${danger.github.pr.number}](${danger.github.pr.html_url}))`;
+const PR_NUMBER = danger.github.pr.number;
+const PR_LINK = `(#${PR_NUMBER})`;
 
 const CHANGELOG_SUMMARY_TITLE = `Instructions and example for changelog`;
-const CHANGELOG_BODY = `Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section. Make sure the entry includes this PR's number.
+const CHANGELOG_BODY = `Please add an entry to \`CHANGELOG.md\` to the "Unreleased" section under the following heading:
 
-Example:`;
+To the changelog entry, please add a link to this PR (consider a more descriptive message):`;
 
-const CHANGELOG_END_BODY = `If none of the above apply, you can opt out of this check by adding \`#skip-changelog\` to the PR description.`;
+const CHANGELOG_END_BODY = `If none of the above apply, you can opt out by adding _#skip-changelog_ to the PR description.`;
 
 function getCleanTitleWithPrLink() {
   const title = danger.github.pr.title;
-  return title.split(": ").slice(-1)[0].trim().replace(/\.+$/, "") + ` ` + PR_LINK;
+  return title.split(": ").slice(-1)[0].trim().replace(/\.+$/, "") + PR_LINK;
 }
 
 function getChangelogDetailsHtml() {
   return `
-### ${CHANGELOG_SUMMARY_TITLE}
+<details>
+<summary><b>\`${CHANGELOG_SUMMARY_TITLE}\`$</b></summary>
 
-${CHANGELOG_BODY}
+\`${CHANGELOG_BODY}\`
 
-\`\`\`markdown
+\`\`\`md
 - ${getCleanTitleWithPrLink()}
 \`\`\`
 
-${CHANGELOG_END_BODY}
+\`${CHANGELOG_END_BODY}\`
+</details>
 `;
 }
 
 function getChangelogDetailsTxt() {
-  return (
-    CHANGELOG_SUMMARY_TITLE +
-    "\n" +
-    CHANGELOG_BODY +
-    "\n" +
-    getCleanTitleWithPrLink() +
-    "\n" +
-    CHANGELOG_END_BODY
-  );
+	return CHANGELOG_SUMMARY_TITLE + '\n' +
+		   CHANGELOG_BODY + '\n' +
+		   getCleanTitleWithPrLink() + '\n' +
+		   CHANGELOG_END_BODY;
 }
 
-function HasPermissionToComment() {
-  return (
-    danger.github.pr.head.repo.git_url == danger.github.pr.base.repo.git_url
-  );
+function HasPermissionToComment(){
+	return danger.github.pr.head.repo.git_url == danger.github.pr.base.repo.git_url;
 }
 
 async function containsChangelog(path) {
@@ -51,35 +47,35 @@ async function containsChangelog(path) {
 
 async function checkChangelog() {
   const skipChangelog =
-    danger.github && (danger.github.pr.body + "").toLowerCase().includes("#skip-changelog");
+    danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
   if (skipChangelog) {
     return;
   }
 
   const hasChangelog = await containsChangelog("CHANGELOG.md");
 
-  if (!hasChangelog) {
-    if (HasPermissionToComment()) {
-      fail("Please consider adding a changelog entry for the next release.");
-      markdown(getChangelogDetailsHtml());
-    } else {
-      //Fallback
-      console.log(
-        "Please consider adding a changelog entry for the next release."
-      );
-      console.log(getChangelogDetailsTxt());
-      process.exitCode = 1;
-    }
+  if (!hasChangelog)
+  {
+	if (HasPermissionToComment())
+	{
+		fail("Please consider adding a changelog entry for the next release.");
+		markdown(getChangelogDetailsHtml());
+	}
+	else
+	{
+		//Fallback
+		console.log("Please consider adding a changelog entry for the next release.");
+		console.log(getChangelogDetailsTxt());
+		process.exitCode = 1;
+	}
   }
 }
 
 async function checkIfFeature() {
-  const title = danger.github.pr.title;
-  if (title.startsWith("feat:") && HasPermissionToComment()) {
-    message(
-      'Do not forget to update <a href="https://github.com/getsentry/sentry-docs">Sentry-docs</a> with your feature once the pull request gets approved.'
-    );
-  }
+   const title = danger.github.pr.title;
+   if (title.startsWith('feat:') && HasPermissionToComment()){
+	 message('Do not forget to update <a href="https://github.com/getsentry/sentry-docs">Sentry-docs</a> with your feature once the pull request gets approved.');
+   }
 }
 
 async function checkAll() {


### PR DESCRIPTION
The current dangerfile requires the changelog entry to have the PR number
and a link to the PR, which is not needed for GitHub Releases. Therefore, 
use the Dangerfile from sentry-cocoa, which doesn't require the link.

#skip-changelog