### PR TITLE
fix: Bug in upload process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- fix: Bug in upload process (#109)
 - fix: Correct link to sentry docs in action description (#104)
 
 ## 1.11.0

--- a/lib/fastlane/plugin/sentry/version.rb
+++ b/lib/fastlane/plugin/sentry/version.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Sentry
     VERSION = "1.11.0"
-    CLI_VERSION = "1.70.1"
+    CLI_VERSION = "1.72.0"
   end
 end


### PR DESCRIPTION
Bump minimum sentry-cli version to 1.72.0,
because of an important bug fix that sometimes
crashed the upload process,
https://github.com/getsentry/sentry-cli/pull/1104.

Fixes GH-108