### PR TITLE
docs: Add docs for sentry-cli-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ sentry_create_deploy(
 )
 ```
 
+### Specify custom sentry-cli path
+
+For every action, you can specify a custom sentry-cli path by adding `sentry_cli_path` to the action. This defaults to `which sentry-cli`.
+
 ### Checking the sentry-cli is installed
 
 Useful for checking that the sentry-cli is installed and meets the minimum version requirements before starting to build your app in your lane.


### PR DESCRIPTION
GH-97 added the possibility to pass a custom sentry-cli path to
every action, but the PR didn't add docs. This PR adds the
missing docs.

#skip-changelog