### PR TITLE
Enha: upload-dif integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,9 +17,15 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'
-      - uses: maierj/fastlane-action@v2.2.0
 
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash
 
-      - run: ./integration.sh
+      - name: Install Google API Client
+        run: sudo gem install google-api-client
+
+      - name: Install Fastlane
+        run: sudo gem install fastlane -NV
+
+      - name: Run integration tests
+        run: ./integration.sh

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,22 @@
+name: integration-test
+
+on:
+  push:
+    branches:
+      -master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+
+      - name: Install sentry-cli
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - run: ./integration.sh

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,16 +14,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10.5'
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'
 
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash
-
-      - name: Install Google API Client
-        run: sudo gem install google-api-client
-
+        
       - name: Install Fastlane
         run: sudo gem install fastlane -NV
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10.5'
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  integration-test:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.6'
+      - uses: maierj/fastlane-action@v2.2.0
 
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -20,9 +20,9 @@ jobs:
 
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash
-        
+
       - name: Install Fastlane
-        run: sudo gem install fastlane -NV
+        run: sudo gem install fastlane
 
       - name: Run integration tests
         run: ./integration.sh

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.10.5'
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1.2'
 
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.5'
 
       - run: gem update bundler
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.5'
+          ruby-version: '2.6'
 
       - run: gem update bundler
 

--- a/fastlane-plugin-sentry.gemspec
+++ b/fastlane-plugin-sentry.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/plugin/sentry/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
   spec.name          = 'fastlane-plugin-sentry'
   spec.version       = Fastlane::Sentry::VERSION
   spec.author        = %q{Sentry}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@ lane :test_big do
   )
 end
 
-lane :integration_test do
+lane :integration_test_upload_dif do
   sentry_upload_dif(
     org_slug: 'sentry-sdks',
     project_slug: 'sentry-fastlane-plugin',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,11 +11,14 @@ lane :test_big do
 end
 
 lane :integration_test_upload_dif do
-  sentry_upload_dif(
-    org_slug: 'sentry-sdks',
-    project_slug: 'sentry-fastlane-plugin',
-    auth_token: 'dummy-auth-token',
-    path: './assets/SwiftExample.app.dSYM.zip',
-    url: "http://127.0.0.1:8000"
-  )
+
+  UI.user_error!("Test failing fastlane call...")
+
+  # sentry_upload_dif(
+  #   org_slug: 'sentry-sdks',
+  #   project_slug: 'sentry-fastlane-plugin',
+  #   auth_token: 'dummy-auth-token',
+  #   path: './assets/SwiftExample.app.dSYM.zip',
+  #   url: "http://127.0.0.1:8000"
+  # )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,3 +9,13 @@ lane :test_big do
     dsym_path: './assets/Big.app.dSYM.zip'
   )
 end
+
+lane :integration_test do
+  sentry_upload_dif(
+    org_slug: 'sentry-sdks',
+    project_slug: 'sentry-fastlane-plugin',
+    auth_token: 'dummy-auth-token',
+    path: './assets/SwiftExample.app.dSYM.zip',
+    url: "http://127.0.0.1:8000"
+  )
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,14 +11,11 @@ lane :test_big do
 end
 
 lane :integration_test_upload_dif do
-
-  UI.user_error!("Test failing fastlane call...")
-
-  # sentry_upload_dif(
-  #   org_slug: 'sentry-sdks',
-  #   project_slug: 'sentry-fastlane-plugin',
-  #   auth_token: 'dummy-auth-token',
-  #   path: './assets/SwiftExample.app.dSYM.zip',
-  #   url: "http://127.0.0.1:8000"
-  # )
+  sentry_upload_dif(
+    org_slug: 'sentry-sdks',
+    project_slug: 'sentry-fastlane-plugin',
+    auth_token: 'dummy-auth-token',
+    path: './assets/SwiftExample.app.dSYM.zip',
+    url: "http://127.0.0.1:8000"
+  )
 end

--- a/integration.sh
+++ b/integration.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+python3 script/integration-test-server.py & fastlane integration_test
+curl http://127.0.0.1:8000/STOP

--- a/integration.sh
+++ b/integration.sh
@@ -1,4 +1,21 @@
 #! /bin/bash
 
-python3 script/integration-test-server.py & fastlane integration_test
-curl http://127.0.0.1:8000/STOP
+start_server() {
+	python3 script/integration-test-server.py
+}
+
+stop_server() {
+	curl http://127.0.0.1:8000/STOP
+}
+
+integration_test_upload_diff() {
+	fastlane integration_test_upload_dif
+}
+
+if ! (start_server & integration_test_upload_diff) ; then
+	stop_server
+  	exit 1
+else 
+	stop_server
+	exit 0
+fi

--- a/script/integration-test-server.py
+++ b/script/integration-test-server.py
@@ -1,42 +1,109 @@
 #!/usr/bin/env python3
 
 from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
 import sys
 import threading
 import binascii
 import json
 
+apiOrg = 'sentry-sdks'
+apiProject = 'sentry-fastlane-plugin'
 uri = urlparse(sys.argv[1] if len(sys.argv) > 1 else 'http://127.0.0.1:8000')
 
+
 class Handler(BaseHTTPRequestHandler):
+    body = None
 
-	def do_GET(self):
-		self.send_response(200)
-		self.send_header('Content-type', 'application/json')
-		self.end_headers()
+    def do_GET(self):
+        self.start_response(HTTPStatus.OK)
 
-		if self.path == "/STOP":
-			print("HTTP server stopping!")
-			threading.Thread(target=self.server.shutdown).start()
-			return
+        if self.path == "/STOP":
+            print("HTTP server stopping!")
+            threading.Thread(target=self.server.shutdown).start()
+            return
 
-		if self.path == "/api/0/organizations/sentry-sdks/chunk-upload/":
-			self.wfile.write(json.dumps({ 
-				'url': uri.geturl() + self.path,
-				'chunkSize': 8388608,
-				'chunksPerRequest': 64,
-				'maxFileSize': 2147483648,
-				'maxRequestSize': 33554432,
-				'concurrency': 1,
-				'hashAlgorithm': 'sha1',
-				'compression': ['gzip'],
-				'accept': ['debug_files','release_files','pdbs','sources','bcsymbolmaps']
-			}).encode('utf-8'))
+        if self.isApi('api/0/organizations/{}/chunk-upload/'.format(apiOrg)):
+            self.writeJSON('{"url":"' + uri.geturl() + self.path + '",'
+                           '"chunkSize":8388608,"chunksPerRequest":64,"maxFileSize":2147483648,'
+                           '"maxRequestSize":33554432,"concurrency":1,"hashAlgorithm":"sha1","compression":["gzip"],'
+                           '"accept":["debug_files","release_files","pdbs","sources","bcsymbolmaps"]}')
+        else:
+            self.end_headers()
+
+        self.flushLogs()
+
+    def do_POST(self):
+        self.start_response(HTTPStatus.OK)
+
+        if self.isApi('api/0/projects/{}/{}/files/difs/assemble/'.format(apiOrg, apiProject)):
+            # Request body example:
+            # {
+            #   "9a01653a...":{"name":"UnityPlayer.dylib","debug_id":"eb4a7644-...","chunks":["f84d3907945cdf41b33da8245747f4d05e6ffcb4", ...]},
+            #   "4185e454...":{"name":"UnityPlayer.dylib","debug_id":"86d95b40-...","chunks":[...]}
+            # }
+            # Response body to let the CLI know we have the symbols already (we don't need to test the actual upload):
+            # {
+            #   "9a01653a...":{"state":"ok","missingChunks":[]},
+            #   "4185e454...":{"state":"ok","missingChunks":[]}
+            # }
+            jsonRequest = json.loads(self.body)
+            jsonResponse = '{'
+            for key, value in jsonRequest.items():
+                jsonResponse += '"{}":{{"state":"ok","missingChunks":[]}},'.format(
+                    key)
+                self.log_message('Received: %40s %40s %s', key,
+                                 value['debug_id'], value['name'])
+            jsonResponse = jsonResponse.rstrip(',') + '}'
+            self.writeJSON(jsonResponse)
+        else:
+            self.end_headers()
+
+        self.flushLogs()
+
+    def start_response(self, code):
+        self.body = None
+        self.log_request(code)
+        self.send_response_only(code)
+
+    def log_request(self, code=None, size=None):
+        if isinstance(code, HTTPStatus):
+            code = code.value
+        body = self.body = self.requestBody()
+        if body:
+            body = self.body[0:min(1000, len(body))]
+        self.log_message('"%s" %s %s%s',
+                         self.requestline, str(code), "({} bytes)".format(size) if size else '', body)
+
+    # Note: this may only be called once during a single request - can't `.read()` the same stream again.
+    def requestBody(self):
+        if self.command == "POST" and 'Content-Length' in self.headers:
+            length = int(self.headers['Content-Length'])
+            content = self.rfile.read(length)
+            try:
+                return content.decode("utf-8")
+            except:
+                return binascii.hexlify(bytearray(content))
+        return None
+
+    def isApi(self, api: str):
+        if self.path.strip('/') == api.strip('/'):
+            self.log_message("Matched API endpoint {}".format(api))
+            return True
+        return False
+
+    def writeJSON(self, string: str):
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(str.encode(string))
+
+    def flushLogs(self):
+        sys.stdout.flush()
+        sys.stderr.flush()
+
 
 print("HTTP server listening on {}".format(uri.geturl()))
 print("To stop the server, execute a GET request to {}/STOP".format(uri.geturl()))
-
-httpd = HTTPServer((uri.hostname, uri.port), Handler)
+httpd = ThreadingHTTPServer((uri.hostname, uri.port), Handler)
 target = httpd.serve_forever()

--- a/script/integration-test-server.py
+++ b/script/integration-test-server.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+import sys
+import threading
+import binascii
+import json
+
+uri = urlparse(sys.argv[1] if len(sys.argv) > 1 else 'http://127.0.0.1:8000')
+
+class Handler(BaseHTTPRequestHandler):
+
+	def do_GET(self):
+		self.send_response(200)
+		self.send_header('Content-type', 'application/json')
+		self.end_headers()
+
+		if self.path == "/STOP":
+			print("HTTP server stopping!")
+			threading.Thread(target=self.server.shutdown).start()
+			return
+
+		if self.path == "/api/0/organizations/sentry-sdks/chunk-upload/":
+			self.wfile.write(json.dumps({ 
+				'url': uri.geturl() + self.path,
+				'chunkSize': 8388608,
+				'chunksPerRequest': 64,
+				'maxFileSize': 2147483648,
+				'maxRequestSize': 33554432,
+				'concurrency': 1,
+				'hashAlgorithm': 'sha1',
+				'compression': ['gzip'],
+				'accept': ['debug_files','release_files','pdbs','sources','bcsymbolmaps']
+			}).encode('utf-8'))
+
+print("HTTP server listening on {}".format(uri.geturl()))
+print("To stop the server, execute a GET request to {}/STOP".format(uri.geturl()))
+
+httpd = HTTPServer((uri.hostname, uri.port), Handler)
+target = httpd.serve_forever()


### PR DESCRIPTION
#skip-changelog

This PR adds an integration test for `upload-diff` action.

- Action is called through a fastlane `lane`
- A mock server returning expected values for `sentry-cli` calls
  - Taken from https://github.com/getsentry/sentry-unity/pull/763
- Bumps required ruby version to `2.6.0`
  - Test action required this