### PR TITLE
fix: Return output from call_sentry_cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.12.2
+
+### Fixes
+
+- fix: Return output from `call_sentry_cli` to allow parsing in `fallback_sentry_cli_auth` (#140)
+
 ## 1.12.1
 
 ### Fixes
@@ -14,7 +20,7 @@
 
 ### Fixes
 
-- Add missing mac supported platform to sentry_upload_dsym (#115)
+- Add missing mac supported platform to `sentry_upload_dsym` (#115)
 
 ## 1.11.1
 

--- a/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/sentry/helper/sentry_helper.rb
@@ -38,13 +38,23 @@ module Fastlane
         end
 
         Open3.popen2e(final_command) do |stdin, stdout_and_stderr, status_thread|
+          # While most of the commands are just a pass-through for stdout/stderr
+          # we do rely on parsing stdout in `fallback_sentry_cli_auth` helper
+          # We can ignore `stderr`, which is responsible for logging
+          # as `sentry-cli info --config-status-json` which we use, doesnt allow `--verbose`.
+          output = []
+
           stdout_and_stderr.each_line do |line|
-            UI.message(line.strip!)
+            l = line.strip!
+            UI.message(l)
+            output << l
           end
 
           unless status_thread.value.success?
             UI.user_error!('Error while calling Sentry CLI')
           end
+
+          output.join
         end
       end
     end


### PR DESCRIPTION
NOTE: This will return concatenated stdout and stderr, but for our use case it's okay (see the reasoning in the comment).
However, It would be best to rewrite it in the future to use `popen3` and threads or `IO.select` to allow for non-blocking buffer reads, and here returns `stdout` only. I don't know ruby well enough to do it swiftly, so I'll leave it to someone else.

Fixes https://github.com/getsentry/sentry-fastlane-plugin/issues/139