### PR TITLE
Enha: Support uploading multiple source map files simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Enha: Pin/Bundle sentry-cli Version (#143)
 - Bump CLI from v1.72.0 to v2.5.2 (#158)
+- Enha: Support uploading multiple source map files simultaneously (#151)
 
 ## 1.12.3
 

--- a/README.md
+++ b/README.md
@@ -145,26 +145,7 @@ sentry_upload_sourcemap(
   app_identifier: '...', # pass in the bundle_identifer of your app
   build: '...', # Optionally pass in the build number of your app
   dist: '...', # optional distribution of the release usually the buildnumber
-  sourcemap: 'main.jsbundle.map', # sourcemap to upload
-  rewrite: true
-)
-```
-
-The `sourcemap` argument also accepts an array of files for uploading multiple
-source maps or bundle files simultaneously. This is required at least when
-using Hermes with React Native on Android.
-
-```ruby
-sentry_upload_sourcemap(
-  api_key: '...',
-  auth_token: '...',
-  org_slug: '...',
-  project_slug: '...',
-  version: '...',
-  app_identifier: '...', # pass in the bundle_identifer of your app
-  build: '...', # Optionally pass in the build number of your app
-  dist: '...', # optional distribution of the release usually the buildnumber
-  sourcemap: ['index.android.bundle', 'index.android.bundle.map'], # sourcemaps to upload
+  sourcemap: 'main.jsbundle.map', # Sourcemap(s) to upload. Path(s) can be a comma-separated string or an array of strings.
   rewrite: true
 )
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Further options:
 - __derived_data__: Optional. Search for debug symbols in Xcode's derived data.
 - __no_zips__: Do not search in ZIP files.
 - __info_plist__: Optional. Optional path to the Info.plist. We will try to find this automatically if run from Xcode.  Providing this information will associate the debug symbols with a specific ITC application and build in Sentry.  Note that if you provide the plist explicitly it must already be processed.
-- __no_reprocessing__: Optional. Do not trigger reprocessing after uploading.                           
+- __no_reprocessing__: Optional. Do not trigger reprocessing after uploading.
 - __force_foreground__: Optional. Wait for the process to finish. By default, the upload process will detach and continue in the background when triggered from Xcode.  When an error happens, a dialog is shown.  If this parameter is passed Xcode will wait for the process to finish before the build finishes and output will be shown in the Xcode build output.
 - __include_sources__: Optional. Include sources from the local file system and upload them as source bundles.
 - __wait__: Wait for the server to fully process uploaded files. Errors can only be displayed if --wait is specified, but this will significantly slow down the upload process.
@@ -146,6 +146,25 @@ sentry_upload_sourcemap(
   build: '...', # Optionally pass in the build number of your app
   dist: '...', # optional distribution of the release usually the buildnumber
   sourcemap: 'main.jsbundle.map', # sourcemap to upload
+  rewrite: true
+)
+```
+
+The `sourcemap` argument also accepts an array of files for uploading multiple
+source maps or bundle files simultaneously. This is required at least when
+using Hermes with React Native on Android.
+
+```ruby
+sentry_upload_sourcemap(
+  api_key: '...',
+  auth_token: '...',
+  org_slug: '...',
+  project_slug: '...',
+  version: '...',
+  app_identifier: '...', # pass in the bundle_identifer of your app
+  build: '...', # Optionally pass in the build number of your app
+  dist: '...', # optional distribution of the release usually the buildnumber
+  sourcemap: ['index.android.bundle', 'index.android.bundle.map'], # sourcemaps to upload
   rewrite: true
 )
 ```

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -10,14 +10,14 @@ module Fastlane
         version = "#{params[:app_identifier]}@#{params[:version]}" if params[:app_identifier]
         version = "#{version}+#{params[:build]}" if params[:build]
 
-        sourcemap = params[:sourcemap]
+        sourcemaps = params[:sourcemap]
 
         command = [
           "releases",
           "files",
           version,
           "upload-sourcemaps",
-          sourcemap.to_s
+          *sourcemaps.map(&:to_s)
         ]
 
         command.push('--rewrite') if params[:rewrite]
@@ -52,12 +52,12 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Upload a sourcemap to a release of a project on Sentry"
+        "Upload one or more sourcemap(s) to a release of a project on Sentry"
       end
 
       def self.details
         [
-          "This action allows you to upload a sourcemap to a release of a project on Sentry.",
+          "This action allows you to upload one or more sourcemap(s) to a release of a project on Sentry.",
           "See https://docs.sentry.io/learn/cli/releases/#upload-sourcemaps for more information."
         ].join(" ")
       end
@@ -79,9 +79,11 @@ module Fastlane
                                        description: "Distribution in release",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :sourcemap,
-                                       description: "Path to the sourcemap to upload",
-                                       verify_block: proc do |value|
-                                         UI.user_error! "Could not find sourcemap at path '#{value}'" unless File.exist?(value)
+                                       description: "Path or an array of paths to the sourcemap(s) to upload",
+                                       verify_block: proc do |values|
+                                        [*values].each do |value|
+                                          UI.user_error! "Could not find sourcemap at path '#{value}'" unless File.exist?(value)
+                                        end
                                        end),
           FastlaneCore::ConfigItem.new(key: :rewrite,
                                        description: "Rewrite the sourcemaps before upload",

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_sourcemap.rb
@@ -16,9 +16,9 @@ module Fastlane
           "releases",
           "files",
           version,
-          "upload-sourcemaps",
-          *sourcemaps.map(&:to_s)
+          "upload-sourcemaps"
         ]
+        command += sourcemaps
 
         command.push('--rewrite') if params[:rewrite]
         command.push('--no-rewrite') unless params[:rewrite]
@@ -80,10 +80,11 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :sourcemap,
                                        description: "Path or an array of paths to the sourcemap(s) to upload",
+                                       type: Array,
                                        verify_block: proc do |values|
-                                        [*values].each do |value|
-                                          UI.user_error! "Could not find sourcemap at path '#{value}'" unless File.exist?(value)
-                                        end
+                                         [*values].each do |value|
+                                           UI.user_error! "Could not find sourcemap at path '#{value}'" unless File.exist?(value)
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :rewrite,
                                        description: "Rewrite the sourcemaps before upload",

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -171,6 +171,26 @@ describe Fastlane do
               rewrite: true)
         end").runner.execute(:test)
       end
+
+      it "accepts multiple source maps" do
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.bundle", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              sourcemap: ['1.bundle', '1.map'],
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
     end
   end
 end

--- a/spec/sentry_upload_sourcemap_spec.rb
+++ b/spec/sentry_upload_sourcemap_spec.rb
@@ -172,12 +172,13 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "accepts multiple source maps" do
+      it "accepts multiple source maps as an array" do
         allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.bundle", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
 
         allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.bundle").and_return(true)
         expect(File).to receive(:exist?).with("1.map").and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -188,6 +189,27 @@ describe Fastlane do
               version: '1.0',
               dist: 'dem',
               sourcemap: ['1.bundle', '1.map'],
+              app_identifier: 'app.idf')
+        end").runner.execute(:test)
+      end
+
+      it "accepts multiple source maps as a comma-separated string" do
+        allow(CredentialsManager::AppfileConfig).to receive(:try_fetch_value).with(:app_identifier).and_return(false)
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "files", "app.idf@1.0", "upload-sourcemaps", "1.bundle", "1.map", "--no-rewrite", "--dist", "dem"]).and_return(true)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with("1.bundle").and_return(true)
+        expect(File).to receive(:exist?).with("1.map").and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_sourcemap(
+              org_slug: 'some_org',
+              api_key: 'something123',
+              project_slug: 'some_project',
+              version: '1.0',
+              dist: 'dem',
+              sourcemap: '1.bundle,1.map',
               app_identifier: 'app.idf')
         end").runner.execute(:test)
       end


### PR DESCRIPTION
Closes #141 

Thanks for the plugin! I noticed the same issue as in #141 and would like to drop our custom shell script step, so here's a quick enhancement for that. I'm a Ruby-noob so let me know if something here should be done differently.

Some cases, such as when using Hermes builds with React Native on Android, require uploading both the bundle file and its corresponding source map simultaneously to be correctly processed by Sentry.

To avoid breaking backwards compatbility, use the same singular argument name but accept both string and array values.