### PR TITLE
Support multiple paths in `upload_dif` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bump CLI from v2.7.0 to v2.8.1 ([#173](https://github.com/getsentry/sentry-fastlane-plugin/pull/173), [#175](https://github.com/getsentry/sentry-fastlane-plugin/pull/175))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#281)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.7.0...2.8.1)
+- Support multiple paths in `upload_diff` command [#177](https://github.com/getsentry/sentry-fastlane-plugin/pull/177)
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Bump CLI from v2.7.0 to v2.8.1 ([#173](https://github.com/getsentry/sentry-fastlane-plugin/pull/173), [#175](https://github.com/getsentry/sentry-fastlane-plugin/pull/175))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#281)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.7.0...2.8.1)
-- Support multiple paths in `upload_diff` command [#177](https://github.com/getsentry/sentry-fastlane-plugin/pull/177)
+- Support multiple paths in `upload_diff` command (#177)
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Bump CLI from v2.7.0 to v2.8.1 ([#173](https://github.com/getsentry/sentry-fastlane-plugin/pull/173), [#175](https://github.com/getsentry/sentry-fastlane-plugin/pull/175))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#281)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.7.0...2.8.1)
-- Support multiple paths in `upload_diff` command (#177)
+- Support multiple paths in `upload_dif` command (#177)
 
 ## 1.14.0
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sentry_upload_dif(
   auth_token: '...', # Do not use if using api_key
   org_slug: '...',
   project_slug: '...',
-  path: '/path/to/files', # Optional. We'll default to '.' when no value is provided.
+  path: '/path/to/files', # Optional. Defaults to '.' when no value is provided. Path(s) can be a string, a comma-separated string, or an array of strings.
 )
 ```
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -6,13 +6,14 @@ module Fastlane
 
         Helper::SentryConfig.parse_api_params(params)
 
-        path = params[:path]
-        path = '.' if path.nil?
+        paths = params[:path]
+        paths = ['.'] if paths.nil?
 
         command = [
-          "upload-dif",
-          path
+          "upload-dif"
         ]
+        command += paths
+
         command.push('--type').push(params[:type]) unless params[:type].nil?
         command.push('--no-unwind') unless params[:no_unwind].nil?
         command.push('--no-debug') unless params[:no_debug].nil?
@@ -51,7 +52,8 @@ module Fastlane
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :path,
-                                       description: "A path to search recursively for symbol files",
+                                       description: "Path or an array of paths to search recursively for symbol files",
+                                       type: Array,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :type,
                                        short_option: "-t",

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -12,6 +12,28 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "supports mupltiple paths as array" do
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path", "fixture-path-2"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              path: ['fixture-path', 'fixture-path-2']
+            )
+        end").runner.execute(:test)
+      end
+
+      it "supports mupltiple paths as comma seperated values" do
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path", "fixture-path-2"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              path: 'fixture-path,fixture-path-2'
+            )
+        end").runner.execute(:test)
+      end
+
       it "includes --path fallback if not present" do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "."]).and_return(true)


### PR DESCRIPTION
Closes #162 

Add the possibility to provide multiple paths to the `upload-dif` command.

https://docs.sentry.io/product/cli/dif/#uploading-files
