### PR TITLE
Updated sentry_set_commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2100)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.7.0...2.10.0)
 - Support multiple paths in `upload_dif` command (#177)
-- set_commits supports --ignore missing (#180)
+- `set_commits` supports `--ignore missing` ([#180](https://github.com/getsentry/sentry-fastlane-plugin/pull/180))
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2100)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.7.0...2.10.0)
 - Support multiple paths in `upload_dif` command (#177)
+- set_commits supports --ignore missing (#180)
 
 ## 1.14.0
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ sentry_set_commits(
   auto: false, # enable completely automated commit management
   clear: false, # clear all current commits from the release
   commit: '...', # commit spec, see `sentry-cli releases help set-commits` for more information
+  ignore_previous_commits: true # Boolean value: Let sentry to ignore previous unknown commits
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ sentry_set_commits(
   auto: false, # enable completely automated commit management
   clear: false, # clear all current commits from the release
   commit: '...', # commit spec, see `sentry-cli releases help set-commits` for more information
-  ignore_previous_commits: true # Boolean value: Let sentry to ignore previous unknown commits
+  ignore_missing: false # Optional boolean value: When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count (or the one specified with `--initial-depth`) instead of failing the command.
 )
 ```
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -63,11 +63,11 @@ module Fastlane
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :commit,
                                        description: "Commit spec, see `sentry-cli releases help set-commits` for more information",
-                                       optional: true)
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :ignore_missing,
                                        description: "When enabled, if the previous release commit was not found in the repository, will create a release with the default commits count (or the one specified with `--initial-depth`) instead of failing the command.",
                                        is_string: false,
-                                       default_value: false),
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -65,7 +65,7 @@ module Fastlane
                                        description: "Commit spec, see `sentry-cli releases help set-commits` for more information",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ignore_missing,
-                                       description: "When enabled, if the previous release commit was not found in the repository, will create a release with the default commits count (or the one specified with `--initial-depth`) instead of failing the command.",
+                                       description: "When enabled, if the previous release commit was not found in the repository, will create a release with the default commits count (or the one specified with `--initial-depth`) instead of failing the command",
                                        is_string: false,
                                        default_value: false)
         ]

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -18,6 +18,7 @@ module Fastlane
 
         command.push('--auto') if params[:auto]
         command.push('--clear') if params[:clear]
+        command.push('--ignore-missing') if params[:ignore_previous_commits]
         command.push('--commit').push(params[:commit]) unless params[:commit].nil?
 
         Helper::SentryHelper.call_sentry_cli(params, command)

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -18,7 +18,7 @@ module Fastlane
 
         command.push('--auto') if params[:auto]
         command.push('--clear') if params[:clear]
-        command.push('--ignore-missing') if params[:ignore_previous_commits]
+        command.push('--ignore-missing') if params[:ignore_missing]
         command.push('--commit').push(params[:commit]) unless params[:commit].nil?
 
         Helper::SentryHelper.call_sentry_cli(params, command)
@@ -64,6 +64,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :commit,
                                        description: "Commit spec, see `sentry-cli releases help set-commits` for more information",
                                        optional: true)
+          FastlaneCore::ConfigItem.new(key: :ignore_missing,
+                                       description: "When enabled, if the previous release commit was not found in the repository, will create a release with the default commits count",
+                                       is_string: false,
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_set_commits.rb
@@ -65,7 +65,7 @@ module Fastlane
                                        description: "Commit spec, see `sentry-cli releases help set-commits` for more information",
                                        optional: true)
           FastlaneCore::ConfigItem.new(key: :ignore_missing,
-                                       description: "When enabled, if the previous release commit was not found in the repository, will create a release with the default commits count",
+                                       description: "When enabled, if the previous release commit was not found in the repository, will create a release with the default commits count (or the one specified with `--initial-depth`) instead of failing the command.",
                                        is_string: false,
                                        default_value: false),
         ]

--- a/spec/sentry_set_commits_spec.rb
+++ b/spec/sentry_set_commits_spec.rb
@@ -114,6 +114,37 @@ describe Fastlane do
               version: '1.0')
         end").runner.execute(:test)
       end
+      
+      it "includes --ignore-missing when true" do
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "set-commits", "1.0", "--ignore-missing"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_set_commits(
+              version: '1.0',
+              ignore_previous_commits: true)
+        end").runner.execute(:test)
+      end
+
+      it "omits --ignore-missing when not present" do
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "set-commits", "1.0"]).and_return(true)
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_set_commits(
+              version: '1.0')
+        end").runner.execute(:test)
+      end
+
+      it "omits --ignore-missing when false" do
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "set-commits", "1.0"]).and_return(true)
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_set_commits(
+              version: '1.0',
+              ignore_previous_commits: false)
+        end").runner.execute(:test)
+      end
+      
     end
   end
 end

--- a/spec/sentry_set_commits_spec.rb
+++ b/spec/sentry_set_commits_spec.rb
@@ -122,7 +122,7 @@ describe Fastlane do
         Fastlane::FastFile.new.parse("lane :test do
             sentry_set_commits(
               version: '1.0',
-              ignore_previous_commits: true)
+              ignore_missing: true)
         end").runner.execute(:test)
       end
 
@@ -141,7 +141,7 @@ describe Fastlane do
         Fastlane::FastFile.new.parse("lane :test do
             sentry_set_commits(
               version: '1.0',
-              ignore_previous_commits: false)
+              ignore_missing: false)
         end").runner.execute(:test)
       end
       

--- a/spec/sentry_set_commits_spec.rb
+++ b/spec/sentry_set_commits_spec.rb
@@ -114,7 +114,7 @@ describe Fastlane do
               version: '1.0')
         end").runner.execute(:test)
       end
-      
+
       it "includes --ignore-missing when true" do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["releases", "set-commits", "1.0", "--ignore-missing"]).and_return(true)
@@ -144,7 +144,6 @@ describe Fastlane do
               ignore_missing: false)
         end").runner.execute(:test)
       end
-      
     end
   end
 end


### PR DESCRIPTION
New feature

1. Updated sentry_set_commits to support --ignore missing.

This PR resolves #179.