### PR TITLE
ci: Remove deprecated setup-ruby action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
 


### PR DESCRIPTION
Replace deprecated actions/setup-ruby@v1 with ruby/setup-ruby@v1.

#skip-changelog