### PR TITLE
Android proguard uuid parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ sentry_upload_proguard(
   project_slug: '...',
   android_manifest_path: 'path to merged AndroidManifest file', # found in `app/build/intermediates/manifests/full`
   mapping_path: 'path to mapping.txt to upload',
+  uuid: '...', # Optional
 )
 ```
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_proguard.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_proguard.rb
@@ -7,6 +7,7 @@ module Fastlane
         # Params - mapping & manifest
         mapping_path = params[:mapping_path]
         android_manifest_path = params[:android_manifest_path]
+        proguard_uuid = params[:uuid]
 
         # Verify files
         UI.user_error!("Mapping file does not exist at path: #{mapping_path}") unless File.exist? mapping_path
@@ -18,6 +19,7 @@ module Fastlane
           android_manifest_path,
           mapping_path
         ]
+        command.push("--uuid").push(proguard_uuid) unless proguard_uuid.nil?
 
         Helper::SentryHelper.call_sentry_cli(params, command)
         UI.success("Successfully uploaded mapping file!")

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_proguard.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_proguard.rb
@@ -55,7 +55,11 @@ module Fastlane
                                        optional: false,
                                        verify_block: proc do |value|
                                                        UI.user_error! "Could not find your merged AndroidManifest file at path '#{value}'" unless File.exist?(value)
-                                                     end)
+                                                     end),
+          FastlaneCore::ConfigItem.new(key: :uuid,
+                                       env_name: "ANDROID_PROGUARD_UUID",
+                                       description: "Explicitly override the UUID of the mapping file with another one",
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
Since there was no cli uuid parameter correspondence in fastlane Plugin, it was added.
This will allow mapping.txt mapping to work.