### PR TITLE
fix: Don't upload code source if "include_source" is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Don't upload code source if "include_source" is false
+
 ## 1.17.0
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Don't upload code source if "include_source" is false
+- Don't upload code source if "include_source" is false (#231)
 
 ## 1.17.0
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -26,7 +26,7 @@ module Fastlane
         command.push('--info-plist').push(params[:info_plist]) unless params[:info_plist].nil?
         command.push('--no-reprocessing') unless params[:no_reprocessing].nil?
         command.push('--force-foreground') unless params[:force_foreground].nil?
-        command.push('--include-sources') unless params[:include_sources] != 'true'
+        command.push('--include-sources') unless params[:include_sources] != true
         command.push('--wait') unless params[:wait].nil?
         command.push('--upload-symbol-maps') unless params[:upload_symbol_maps].nil?
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dif.rb
@@ -26,7 +26,7 @@ module Fastlane
         command.push('--info-plist').push(params[:info_plist]) unless params[:info_plist].nil?
         command.push('--no-reprocessing') unless params[:no_reprocessing].nil?
         command.push('--force-foreground') unless params[:force_foreground].nil?
-        command.push('--include-sources') unless params[:include_sources].nil?
+        command.push('--include-sources') unless params[:include_sources] != 'true'
         command.push('--wait') unless params[:wait].nil?
         command.push('--upload-symbol-maps') unless params[:upload_symbol_maps].nil?
 

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -284,7 +284,7 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "dont includes --include_sources when false" do
+      it "dont include --include_sources when false" do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path"]).and_return(true)
 

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -284,14 +284,13 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "dont includes --include_sources when false" do
+      it "dont include --include_sources when false" do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              path: 'fixture-path',
-              include_sources: false
+              path: 'fixture-path'
             )
         end").runner.execute(:test)
       end

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -284,6 +284,18 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "dont includes --include_sources when false" do
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path"]).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_dif(
+              path: 'fixture-path',
+              include_sources: false
+            )
+        end").runner.execute(:test)
+      end
+
       it "includes --wait when true" do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path", "--wait"]).and_return(true)

--- a/spec/sentry_upload_dif_spec.rb
+++ b/spec/sentry_upload_dif_spec.rb
@@ -284,13 +284,14 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "dont include --include_sources when false" do
+      it "dont includes --include_sources when false" do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(anything, ["upload-dif", "fixture-path"]).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
             sentry_upload_dif(
-              path: 'fixture-path'
+              path: 'fixture-path',
+              include_sources: false
             )
         end").runner.execute(:test)
       end


### PR DESCRIPTION
We're just checking whether `include_source` is nil or not in order to pass the argument to sentry-cli.

Fixing this and checking whether `include_source` is true

close #227 