### PR TITLE
Update LICENSE date range to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2024 Sentry
+Copyright (c) 2017-2025 Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Related Cocoa PR https://github.com/getsentry/sentry-cocoa/pull/4702.

#skip-changelog