### PR TITLE
chore: Remove workflows Codeowners file

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @philipphofmann @brustolin @denrase


### PR DESCRIPTION
We don't need two Codeowners files. One is enough.

#skip-changelog