### PR TITLE
feat(size-analysis): Add functionality and tests for iOS mobile app upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `sentry_upload_mobile_app` action to upload iOS app archives (.xcarchive) using `sentry-cli mobile-app upload` command [#320](https://github.com/getsentry/sentry-fastlane-plugin/pull/320)
+- Add `sentry_upload_mobile_app` action to upload iOS app archives (.xcarchive) to Sentry [#320](https://github.com/getsentry/sentry-fastlane-plugin/pull/320)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `sentry_upload_mobile_app` action to upload iOS app archives (.xcarchive) to Sentry [#320](https://github.com/getsentry/sentry-fastlane-plugin/pull/320)
+- Add `sentry upload build` action to upload iOS app archives (.xcarchive) to Sentry [#320](https://github.com/getsentry/sentry-fastlane-plugin/pull/320)
 
 ### Dependencies
 
@@ -287,7 +287,7 @@ We bumped the minimum sentry-cli version to `1.70.1` because it includes an esse
 
 ### Fixes
 
-- fix: Upload Dif use '-' instead of '\_' ([#99](https://github.com/getsentry/sentry-fastlane-plugin/pull/99))
+- fix: Upload Dif use '-' instead of '_' ([#99](https://github.com/getsentry/sentry-fastlane-plugin/pull/99))
 
 ## 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `sentry_upload_mobile_app` action to upload iOS app archives (.xcarchive) using `sentry-cli mobile-app upload` command [#320](https://github.com/getsentry/sentry-fastlane-plugin/pull/320)
+
 ### Dependencies
 
 - Bump CLI from v2.51.0 to v2.53.0 ([#331](https://github.com/getsentry/sentry-fastlane-plugin/pull/331), [#334](https://github.com/getsentry/sentry-fastlane-plugin/pull/334))
@@ -283,7 +287,7 @@ We bumped the minimum sentry-cli version to `1.70.1` because it includes an esse
 
 ### Fixes
 
-- fix: Upload Dif use '-' instead of '_' ([#99](https://github.com/getsentry/sentry-fastlane-plugin/pull/99))
+- fix: Upload Dif use '-' instead of '\_' ([#99](https://github.com/getsentry/sentry-fastlane-plugin/pull/99))
 
 ## 1.10.0
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ sentry_upload_mobile_app(
 )
 ```
 
-By default the `SharedValue::XCODEBUILD_ARCHIVE` sets the `xarchive_path` parameter if set by a prior lane.
+By default the `SharedValue::XCODEBUILD_ARCHIVE` sets the `xarchive_path` parameter if set by a prior lane such as `build_app`.
 
 This action is only supported on iOS platform.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ sentry_upload_mobile_app(
 )
 ```
 
-The `SENTRY_XCARCHIVE_PATH` environment variable may be used in place of the `xcarchive_path` parameter.
+By default the `SharedValue::XCODEBUILD_ARCHIVE` sets the `xarchive_path` parameter if set by a prior lane.
 
 This action is only supported on iOS platform.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ sentry_upload_mobile_app(
 )
 ```
 
-By default the `SharedValue::XCODEBUILD_ARCHIVE` sets the `xarchive_path` parameter if set by a prior lane such as `build_app`.
+By default the `SharedValue::XCODEBUILD_ARCHIVE` sets the `xcarchive_path` parameter if set by a prior lane such as `build_app`.
 
 This action is only supported on iOS platform.
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Further options:
 - __symbol_maps__: Optional. Optional path to BCSymbolMap files which are used to resolve hidden symbols in dSYM files downloaded from iTunes Connect. This requires the dsymutil tool to be available.
 - __derived_data__: Optional. Search for debug symbols in Xcode's derived data.
 - __no_zips__: Do not search in ZIP files.
-- __info_plist__: Optional. Optional path to the Info.plist. We will try to find this automatically if run from Xcode.  Providing this information will associate the debug symbols with a specific ITC application and build in Sentry.  Note that if you provide the plist explicitly it must already be processed.
+- __info_plist__: Optional. Optional path to the Info.plist. We will try to find this automatically if run from Xcode. Providing this information will associate the debug symbols with a specific ITC application and build in Sentry. Note that if you provide the plist explicitly it must already be processed.
 - __no_reprocessing__: Optional. Do not trigger reprocessing after uploading.
-- __force_foreground__: Optional. __Deprecated NoOp since 1.26.0. Before v 1.26.0__: Wait for the process to finish. By default, the upload process will detach and continue in the background when triggered from Xcode.  When an error happens, a dialog is shown.  If this parameter is passed Xcode will wait for the process to finish before the build finishes and output will be shown in the Xcode build output.
+- __force_foreground__: Optional. __Deprecated NoOp since 1.26.0. Before v 1.26.0__: Wait for the process to finish. By default, the upload process will detach and continue in the background when triggered from Xcode. When an error happens, a dialog is shown. If this parameter is passed Xcode will wait for the process to finish before the build finishes and output will be shown in the Xcode build output.
 - __include_sources__: Optional. Include sources from the local file system and upload them as source bundles.
 - __wait__: Wait for the server to fully process uploaded files. Errors can only be displayed if --wait is specified, but this will significantly slow down the upload process.
 - __upload_symbol_maps__: Optional. Upload any BCSymbolMap files found to allow Sentry to resolve hidden symbols, e.g. when it downloads dSYMs directly from App Store Connect or when you upload dSYMs without first resolving the hidden symbols using --symbol-maps.
@@ -111,6 +111,24 @@ sentry_upload_dsym(
   info_plist: '...' # optional, sentry-cli tries to find the correct plist by itself
 )
 ```
+
+### Uploading iOS App Archives
+
+Upload iOS app archives (.xcarchive) to Sentry for improved symbolication and source context.
+
+```ruby
+sentry_upload_mobile_app(
+  api_key: '...', # Do not use if using auth_token
+  auth_token: '...', # Do not use if using api_key
+  org_slug: '...',
+  project_slug: '...',
+  xcarchive_path: './build/MyApp.xcarchive', # Path to your .xcarchive file
+)
+```
+
+The `SENTRY_XCARCHIVE_PATH` environment variable may be used in place of the `xcarchive_path` parameter.
+
+This action is only supported on iOS platform.
 
 ### Creating & Finalizing Releases
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
@@ -2,8 +2,6 @@ module Fastlane
   module Actions
     class SentryUploadMobileAppAction < Action
       def self.run(params)
-        require 'shellwords'
-
         Helper::SentryConfig.parse_api_params(params)
 
         # Verify xcarchive path
@@ -30,9 +28,7 @@ module Fastlane
       end
 
       def self.details
-        [
-          "This action allows you to upload iOS app archives (.xcarchive) to Sentry."
-        ].join(" ")
+        "This action allows you to upload iOS app archives (.xcarchive) to Sentry."
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
@@ -1,0 +1,69 @@
+module Fastlane
+  module Actions
+    class SentryUploadMobileAppAction < Action
+      def self.run(params)
+        require 'shellwords'
+
+        Helper::SentryConfig.parse_api_params(params)
+
+        # Verify xcarchive path
+        xcarchive_path = params[:xcarchive_path]
+        UI.user_error!("Could not find xcarchive at path '#{xcarchive_path}'") unless File.exist?(xcarchive_path)
+        UI.user_error!("Path '#{xcarchive_path}' is not an xcarchive") unless File.extname(xcarchive_path) == '.xcarchive'
+
+        command = [
+          "mobile-app",
+          "upload",
+          File.absolute_path(xcarchive_path)
+        ]
+
+        Helper::SentryHelper.call_sentry_cli(params, command)
+        UI.success("Successfully uploaded mobile app archive: #{xcarchive_path}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload iOS app archive to Sentry"
+      end
+
+      def self.details
+        [
+          "This action allows you to upload iOS app archives (.xcarchive) to Sentry.",
+          "The uploaded archive can be used for various Sentry features including improved symbolication and source context."
+        ].join(" ")
+      end
+
+      def self.available_options
+        Helper::SentryConfig.common_api_config_items + [
+          FastlaneCore::ConfigItem.new(key: :xcarchive_path,
+                                       env_name: "SENTRY_XCARCHIVE_PATH",
+                                       description: "Path to your iOS app archive (.xcarchive)",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not find xcarchive at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("Path '#{value}' is not an xcarchive") unless File.extname(value) == '.xcarchive'
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :no_upload,
+                                       description: "Only process the archive without uploading",
+                                       is_string: false,
+                                       default_value: false,
+                                       optional: true)
+        ]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.authors
+        ["nelsonosacky"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
@@ -10,7 +10,7 @@ module Fastlane
         UI.user_error!("Path '#{xcarchive_path}' is not an xcarchive") unless File.extname(xcarchive_path) == '.xcarchive'
 
         command = [
-          "mobile-app",
+          "build",
           "upload",
           File.absolute_path(xcarchive_path)
         ]

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_mobile_app.rb
@@ -31,25 +31,19 @@ module Fastlane
 
       def self.details
         [
-          "This action allows you to upload iOS app archives (.xcarchive) to Sentry.",
-          "The uploaded archive can be used for various Sentry features including improved symbolication and source context."
+          "This action allows you to upload iOS app archives (.xcarchive) to Sentry."
         ].join(" ")
       end
 
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :xcarchive_path,
-                                       env_name: "SENTRY_XCARCHIVE_PATH",
                                        description: "Path to your iOS app archive (.xcarchive)",
+                                       default_value: Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE],
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find xcarchive at path '#{value}'") unless File.exist?(value)
                                          UI.user_error!("Path '#{value}' is not an xcarchive") unless File.extname(value) == '.xcarchive'
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :no_upload,
-                                       description: "Only process the archive without uploading",
-                                       is_string: false,
-                                       default_value: false,
-                                       optional: true)
+                                       end)
         ]
       end
 
@@ -58,7 +52,7 @@ module Fastlane
       end
 
       def self.authors
-        ["nelsonosacky"]
+        ["runningcode"]
       end
 
       def self.is_supported?(platform)

--- a/spec/sentry_upload_mobile_app_spec.rb
+++ b/spec/sentry_upload_mobile_app_spec.rb
@@ -1,0 +1,87 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "upload mobile app" do
+      # We'll use the dSYM file as a mock xcarchive for testing since we need an existing file
+      let(:mock_xcarchive_path) { File.absolute_path './assets/SwiftExample.app.dSYM.zip' }
+
+      it "fails when xcarchive path does not exist" do
+        non_existent_path = './assets/NonExistent.xcarchive'
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_mobile_app(
+              auth_token: 'test-token',
+              org_slug: 'test-org',
+              project_slug: 'test-project',
+              xcarchive_path: '#{non_existent_path}')
+          end").runner.execute(:test)
+        end.to raise_error("Could not find xcarchive at path '#{non_existent_path}'")
+      end
+
+      it "fails when file is not an xcarchive" do
+        # Mock a file that exists but doesn't have .xcarchive extension
+        invalid_archive_path = './assets/test.zip'
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with(invalid_archive_path).and_return(true)
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            sentry_upload_mobile_app(
+              auth_token: 'test-token',
+              org_slug: 'test-org',
+              project_slug: 'test-project',
+              xcarchive_path: '#{invalid_archive_path}')
+          end").runner.execute(:test)
+        end.to raise_error("Path '#{invalid_archive_path}' is not an xcarchive")
+      end
+
+      it "calls sentry-cli with basic parameters" do
+        # Mock the file to have .xcarchive extension
+        mock_path = './assets/Test.xcarchive'
+
+        allow(File).to receive(:exist?).with(mock_path).and_return(true)
+        allow(File).to receive(:extname).with(mock_path).and_return('.xcarchive')
+
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+          anything,
+          ["mobile-app", "upload", anything]
+        ).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          sentry_upload_mobile_app(
+            auth_token: 'test-token',
+            org_slug: 'test-org',
+            project_slug: 'test-project',
+            xcarchive_path: '#{mock_path}')
+        end").runner.execute(:test)
+      end
+
+      it "uses environment variables for xcarchive path" do
+        mock_path = './assets/Test.xcarchive'
+
+        # Stub environment variables
+        stub_const('ENV', {
+                     'SENTRY_XCARCHIVE_PATH' => mock_path
+                   })
+
+        allow(File).to receive(:exist?).with(mock_path).and_return(true)
+        allow(File).to receive(:extname).with(mock_path).and_return('.xcarchive')
+
+        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+          anything,
+          ["mobile-app", "upload", anything]
+        ).and_return(true)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          sentry_upload_mobile_app(
+            auth_token: 'test-token',
+            org_slug: 'test-org',
+            project_slug: 'test-project')
+        end").runner.execute(:test)
+      end
+    end
+  end
+end

--- a/spec/sentry_upload_mobile_app_spec.rb
+++ b/spec/sentry_upload_mobile_app_spec.rb
@@ -58,7 +58,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
           anything,
-          ["mobile-app", "upload", anything]
+          ["build", "upload", anything]
         ).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -86,7 +86,7 @@ describe Fastlane do
         expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
         expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
           anything,
-          ["mobile-app", "upload", anything]
+          ["build", "upload", anything]
         ).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
This calls `sentry-cli mobile-app upload` with a path to the xcarchive.
The lane looks like this (also documented in README):
```
sentry_upload_mobile_app(
  api_key: '...', # Do not use if using auth_token
  auth_token: '...', # Do not use if using api_key
  org_slug: '...',
  project_slug: '...',
  xcarchive_path: './build/MyApp.xcarchive', # Path to your .xcarchive file
)
```

The `xcarchive_path` is automatically inferred from `SharedValue::XCODEBUILD_ARCHIVE` and can be overridden.

See this internal doc for more details on the implementation of this feature: https://www.notion.so/sentry/1f68b10e4b5d80b1a127fb174f87c555

#skip-changelog