### PR TITLE
refactor: Rename sentry_upload_mobile_app to sentry_upload_build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Add `sentry upload build` action to upload iOS app archives (.xcarchive) to Sentry [#320](https://github.com/getsentry/sentry-fastlane-plugin/pull/320)
-- Add git context parameters to `sentry_upload_mobile_app` action for enhanced context including commit SHAs, branch names, repository information, and pull request details [#335](https://github.com/getsentry/sentry-fastlane-plugin/pull/335)
+- Add git context parameters to `sentry_upload_build` action for enhanced context including commit SHAs, branch names, repository information, and pull request details [#335](https://github.com/getsentry/sentry-fastlane-plugin/pull/335)
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ sentry_upload_dsym(
 )
 ```
 
-### Uploading iOS App Archives
+### Uploading iOS Build Archives
 
-Upload iOS app archives (.xcarchive) to Sentry for improved symbolication and source context.
+Upload iOS build archives (.xcarchive) to Sentry for improved symbolication and source context.
 
 ```ruby
-sentry_upload_mobile_app(
+sentry_upload_build(
   api_key: '...', # Do not use if using auth_token
   auth_token: '...', # Do not use if using api_key
   org_slug: '...',

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    class SentryUploadMobileAppAction < Action
+    class SentryUploadBuildAction < Action
       def self.run(params)
         Helper::SentryConfig.parse_api_params(params)
 
@@ -27,7 +27,7 @@ module Fastlane
         command << "--build-configuration" << params[:build_configuration] if params[:build_configuration]
 
         Helper::SentryHelper.call_sentry_cli(params, command)
-        UI.success("Successfully uploaded mobile app archive: #{xcarchive_path}")
+        UI.success("Successfully uploaded build archive: #{xcarchive_path}")
       end
 
       #####################################################
@@ -35,17 +35,17 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Upload iOS app archive to Sentry with optional git context"
+        "Upload iOS build archive to Sentry with optional git context"
       end
 
       def self.details
-        "This action allows you to upload iOS app archives (.xcarchive) to Sentry with optional git-related parameters for enhanced context including commit SHAs, branch names, repository information, and pull request details."
+        "This action allows you to upload iOS build archives (.xcarchive) to Sentry with optional git-related parameters for enhanced context including commit SHAs, branch names, repository information, and pull request details."
       end
 
       def self.available_options
         Helper::SentryConfig.common_api_config_items + [
           FastlaneCore::ConfigItem.new(key: :xcarchive_path,
-                                       description: "Path to your iOS app archive (.xcarchive)",
+                                       description: "Path to your iOS build archive (.xcarchive)",
                                        default_value: Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE],
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find xcarchive at path '#{value}'") unless File.exist?(value)

--- a/spec/sentry_upload_build_spec.rb
+++ b/spec/sentry_upload_build_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "upload mobile app" do
+    describe "upload build" do
       # We'll use the dSYM file as a mock xcarchive for testing since we need an existing file
       let(:mock_xcarchive_path) { File.absolute_path './assets/SwiftExample.app.dSYM.zip' }
 
@@ -21,7 +21,7 @@ describe Fastlane do
 
         expect do
           Fastlane::FastFile.new.parse("lane :test do
-            sentry_upload_mobile_app(
+            sentry_upload_build(
               auth_token: 'test-token',
               org_slug: 'test-org',
               project_slug: 'test-project',
@@ -39,7 +39,7 @@ describe Fastlane do
 
         expect do
           Fastlane::FastFile.new.parse("lane :test do
-            sentry_upload_mobile_app(
+            sentry_upload_build(
               auth_token: 'test-token',
               org_slug: 'test-org',
               project_slug: 'test-project',
@@ -62,7 +62,7 @@ describe Fastlane do
         ).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
-          sentry_upload_mobile_app(
+          sentry_upload_build(
             auth_token: 'test-token',
             org_slug: 'test-org',
             project_slug: 'test-project',
@@ -90,7 +90,7 @@ describe Fastlane do
         ).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
-          sentry_upload_mobile_app(
+          sentry_upload_build(
             auth_token: 'test-token',
             org_slug: 'test-org',
             project_slug: 'test-project')
@@ -110,7 +110,7 @@ describe Fastlane do
         ).and_return(true)
 
         Fastlane::FastFile.new.parse("lane :test do
-          sentry_upload_mobile_app(
+          sentry_upload_build(
             auth_token: 'test-token',
             org_slug: 'test-org',
             project_slug: 'test-project',


### PR DESCRIPTION
## Summary

This change aligns with the sentry-cli subcommand rename from `mobile-app` to `build`. 
This changes the API of the fastlane plugin from `sentry_upload_mobile_app()` to `sentry_upload_build()`

#skip-changelog (skipping changelog since this change wasn't released publicly so I don't think it warrants a changelog)
