### PR TITLE
ci(workflows): Add manual trigger for dependency update workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   update-cli:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to the dependency update workflow, allowing manual execution from the GitHub Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)