### PR TITLE
chore(ci): Migrate danger workflow to v3

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,6 +16,6 @@ concurrency:
 jobs:
   danger:
     name: Danger
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: getsentry/github-workflows/danger@v3


### PR DESCRIPTION
Based on changes proposed in #350 by @vaind, opened as another PR due to fix CodeQL not being triggered from forks:

---

## Summary

Migrates the Danger workflow from v2 (reusable workflow) to v3 (composite action).

Closes #345

## Changes

This PR correctly performs the structural migration required for v3:

**File: `.github/workflows/danger.yml`**

```diff
 jobs:
   danger:
     name: Danger
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/danger@v3
```

## Why the Dependabot PR Was Incorrect

The Dependabot PR #345 incorrectly just changed the version from `@v2` to `@v3` without restructuring the workflow file. V3 is a breaking change that requires:
1. Adding `runs-on: ubuntu-latest` to each job
2. Converting to step-based structure
3. Changing the action path from `.github/workflows/danger.yml` to just `danger`

## Benefits

- Latest Danger JS version (v13.0.4)
- Better conventional commit scope handling
- Enhanced support for non-conventional PR titles

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)