### PR TITLE
ci(release): Fix preReleaseCommand in .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,6 @@
 minVersion: '0.23.1'
 changelogPolicy: auto
-preReleaseCommand: ruby .scripts/bump-version.rb "$CRAFT_OLD_VERSION" "$CRAFT_NEW_VERSION"
+preReleaseCommand: ruby .scripts/bump-version.rb
 targets:
     - name: gem
     - name: registry


### PR DESCRIPTION
Reverts incorrect change from https://github.com/getsentry/sentry-fastlane-plugin/commit/0e372988a12d98d3e84344a32e456d11d775c162