### PR TITLE
chore: Duplicate changes of v2.0.0-rc.1 to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+Due to sentry-cli 3.0.0 upgrade, the following breaking changes have been made ([#370](https://github.com/getsentry/sentry-fastlane-plugin/pull/370)):
+
+- **`sentry_upload_file` action has been removed**: The `releases files` commands were removed in sentry-cli 3.0.0. Users should migrate to `sentry_upload_sourcemap` for source maps or other specialized upload actions.
+- **`android_manifest_path` parameter in `sentry_upload_proguard` has been removed**: The `--android-manifest` argument was removed in sentry-cli 3.0.0 and is no longer needed. Any Fastfiles still using this parameter will need to remove it.
+- **`path` parameter default behavior changed in `sentry_debug_files_upload`**: The `path` parameter now defaults to `DSYM_OUTPUT_PATH` from fastlane's lane context if available (set by actions like `build_app` or `ipa`), otherwise falls back to `'.'` (current directory). This changes the default behavior when `DSYM_OUTPUT_PATH` is set, which may affect users who were relying on the previous behavior of always searching from the current directory. Users can explicitly specify `path: '.'` to maintain the previous behavior. This addresses issue [#377](https://github.com/getsentry/sentry-fastlane-plugin/issues/377).
+- **`api_key` parameter has been removed**: The `api_key` parameter has been removed in favor of `auth_token`. All actions now require `auth_token` for authentication. Users should update their Fastfiles to use `auth_token` instead of `api_key`. ([#376](https://github.com/getsentry/sentry-fastlane-plugin/pull/376))
+- **`force_foreground` parameter has been removed**: This parameter was deprecated as a no-op since v1.26.0 and has now been removed from `sentry_debug_files_upload`. Users should remove this parameter from their Fastfiles. ([#376](https://github.com/getsentry/sentry-fastlane-plugin/pull/376))
+- **`sentry_upload_dsym` action has been removed**: This action has been deprecated in favor of `sentry_debug_files_upload`. Users should migrate to `sentry_debug_files_upload` with the appropriate `path` parameter. ([#375](https://github.com/getsentry/sentry-fastlane-plugin/pull/375))
+- **`sentry_upload_dif` action has been removed**: This action has been deprecated in favor of `sentry_debug_files_upload`. Users should migrate to `sentry_debug_files_upload` with the appropriate `path` parameter. ([#375](https://github.com/getsentry/sentry-fastlane-plugin/pull/375))
+- **`ids` parameter renamed to `id` in `sentry_debug_files_upload`**: The parameter has been renamed from `ids` to `id` to match sentry-cli v3. Users should update their Fastfiles to use `id` instead of `ids`.
+- **Removed deprecated parameters from `sentry_debug_files_upload`**: The following parameters have been removed as they are no longer supported in sentry-cli v3: `info_plist`, `no_reprocessing`, `upload_symbol_maps`. Users should remove these parameters from their Fastfiles.
+
+See the [sentry-cli 3.0.0 release notes](https://github.com/getsentry/sentry-cli/releases/tag/3.0.0) for more details on CLI changes.
+
+### Features
+
+- Set `SENTRY_PIPELINE` environment variable for all sentry-cli invocations to identify the plugin and version ([#365](https://github.com/getsentry/sentry-fastlane-plugin/pull/365))
+- **Added missing sentry-cli v3 options to all actions**: All actions have been updated to support all available options from sentry-cli version 3.0.1:
+  - **`sentry_debug_files_upload`**: Added `wait_for`, `no_upload`, `il2cpp_mapping` options. Fixed `id` parameter (was `ids`). Updated type validation to include `jvm`, `portablepdb`, and `wasm` types. Removed deprecated options (`info_plist`, `no_reprocessing`, `upload_symbol_maps`) that are no longer supported in sentry-cli v3. (#382)
+  - **`sentry_upload_sourcemap`**: Added `url_suffix`, `note`, `validate`, `decompress`, `wait`, `wait_for`, `no_sourcemap_reference`, `debug_id_reference`, `bundle`, `bundle_sourcemap`, `ext` (array support), and `strict` options.
+  - **`sentry_upload_proguard`**: Added `no_upload`, `write_properties`, `require_one`, and `uuid` options.
+  - **`sentry_upload_build`**: Added `release_notes`, `force_git_metadata`, and `no_git_metadata` options.
+  - **`sentry_create_release`**: Added `url` option.
+  - **`sentry_finalize_release`**: Added `url` and `released` options.
+  - **`sentry_set_commits`**: Added `local` and `initial_depth` options.
+
+### Improvements
+
+- **`sentry_upload_sourcemap` internal command changed**: Now uses `sourcemaps upload --release <version>` instead of `releases files <version> upload-sourcemaps`. This is an internal change and should not affect users unless they are mocking or testing the CLI commands ([#370](https://github.com/getsentry/sentry-fastlane-plugin/pull/370)).
+
+### Dependencies
+
+- Bump CLI from v2.58.2 to v3.1.0 ([#366](https://github.com/getsentry/sentry-fastlane-plugin/pull/366), [#367](https://github.com/getsentry/sentry-fastlane-plugin/pull/367), [#369](https://github.com/getsentry/sentry-fastlane-plugin/pull/369), [#371](https://github.com/getsentry/sentry-fastlane-plugin/pull/371), [#378](https://github.com/getsentry/sentry-fastlane-plugin/pull/378), [#383](https://github.com/getsentry/sentry-fastlane-plugin/pull/383))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#310)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.58.2...3.1.0)
+
 ## 2.0.0-rc.1
 
 ### Breaking Changes


### PR DESCRIPTION
Duplicates the changelog to `## Unreleased` in preparation for the next release candidate

#skip-changelog