### PR TITLE
Support for uploading Dart symbol maps for Flutter symbolication

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ sentry_upload_dart_symbols(
   debug_file_paths: [ # Array of native debug file paths to pair with the symbol map
     'path/to/App.xcframework/ios-arm64/App.framework.dSYM',
     'path/to/libapp.so'
-  ],
-  wait: false # Optional. Wait for the server to fully process uploaded files
+  ]
 )
 ```
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_dart_symbols.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_dart_symbols.rb
@@ -49,9 +49,6 @@ module Fastlane
             command.push('--org').push(params[:org_slug]) unless params[:org_slug].nil?
             command.push('--project').push(params[:project_slug]) unless params[:project_slug].nil?
 
-            # Add wait flag if specified
-            command.push('--wait') if params[:wait] == true
-
             # Add the symbol map and debug file paths
             command.push(symbol_map_path)
             command.push(debug_file_path)
@@ -197,11 +194,7 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("debug_file_paths must be an array") unless value.is_a?(Array)
                                          UI.user_error!("debug_file_paths cannot be empty") if value.empty?
-                                       end),
-          FastlaneCore::ConfigItem.new(key: :wait,
-                                       description: "Wait for the server to fully process uploaded files",
-                                       is_string: false,
-                                       optional: true)
+                                       end)
         ]
       end
 

--- a/spec/sentry_upload_dart_symbols_spec.rb
+++ b/spec/sentry_upload_dart_symbols_spec.rb
@@ -107,31 +107,6 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
-      it "includes --wait flag when specified" do
-        symbol_map_path = File.absolute_path './assets/AndroidManifest.xml'
-        debug_file_path = File.absolute_path './assets/AndroidManifest.xml'
-
-        expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
-
-        # Mock fetch_debug_id and prepend_debug_id_marker
-        allow(Fastlane::Actions::SentryUploadDartSymbolsAction).to receive(:fetch_debug_id).and_return('test-debug-id-123')
-        allow(Fastlane::Actions::SentryUploadDartSymbolsAction).to receive(:prepend_debug_id_marker).and_return(nil)
-
-        expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli)
-          .with(anything, ["dart-symbol-map", "upload", "--org", "some_org", "--project", "some_project", "--wait", symbol_map_path, debug_file_path])
-          .and_return(true)
-
-        Fastlane::FastFile.new.parse("lane :test do
-          sentry_upload_dart_symbols(
-            org_slug: 'some_org',
-            auth_token: 'something123',
-            project_slug: 'some_project',
-            symbol_map_path: '#{symbol_map_path}',
-            debug_file_paths: ['#{debug_file_path}'],
-            wait: true)
-        end").runner.execute(:test)
-      end
-
       it "continues on partial failures and reports summary" do
         symbol_map_path = File.absolute_path './assets/AndroidManifest.xml'
         debug_file_path_1 = File.absolute_path './assets/AndroidManifest.xml'


### PR DESCRIPTION
## Motivation

We have a Flutter project that uses Fastlane for CI/CD. When building obfuscated Flutter releases, we need to upload Dart symbol maps (obfuscation maps) to Sentry for proper crash symbolication. While the `sentry-dart-plugin` supports this functionality, there was no equivalent action available in the Fastlane plugin for our team.

## Changes

This PR adds a new `sentry_upload_dart_symbols` action that mirrors the functionality of the Flutter plugin's `DartSymbolMapUploader`:

- **New action**: `sentry_upload_dart_symbols` that uploads Dart symbol maps paired with native debug files
- **Debug ID pairing**: Fetches debug IDs from native debug files and prepends them to the symbol map to ensure proper pairing in Sentry
- **Batch upload support**: Handles multiple debug files in a single action call
- **Resilient error handling**: Continues uploading remaining files on partial failures and reports a summary
- **Comprehensive tests**: Full test coverage with 8 test cases

## Usage Example

```ruby
sentry_upload_dart_symbols(
  auth_token: ENV['SENTRY_AUTH_TOKEN'],
  org_slug: 'my-org',
  project_slug: 'my-flutter-app',
  symbol_map_path: 'build/app/outputs/symbols/release/symbols.json',
  debug_file_paths: [
    'build/ios/archive/Runner.xcarchive/dSYMs/Runner.framework.dSYM',
    'build/app/intermediates/native_libs/release/lib/arm64-v8a/libapp.so'
  ]
)