### PR TITLE
feat(snapshots): add diff_threshold parameter to sentry_upload_snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add parameter `diff_threshold` to `sentry_upload_snapshots` ([#509](https://github.com/getsentry/sentry-fastlane-plugin/pull/509))
+
 ### Dependencies
 
 - Bump CLI from v3.5.1 to v3.6.0 ([#504](https://github.com/getsentry/sentry-fastlane-plugin/pull/504))

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_snapshots.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_snapshots.rb
@@ -14,9 +14,14 @@ module Fastlane
           "snapshots",
           "upload",
           "--app-id",
-          app_id,
-          path
+          app_id
         ]
+
+        if params[:diff_threshold]
+          command += ["--diff-threshold", params[:diff_threshold].to_s]
+        end
+
+        command << path
 
         Helper::SentryConfig.build_vcs_command(command, params)
 
@@ -47,7 +52,17 @@ module Fastlane
                                                      end),
           FastlaneCore::ConfigItem.new(key: :app_id,
                                        description: "Application identifier",
-                                       optional: false)
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :diff_threshold,
+                                       description: "Only report images as changed if their difference percentage exceeds this value (0.0–1.0). " \
+                                                    "For example, 0.001 ignores changes affecting less than 0.1% of pixels. " \
+                                                    "Useful for filtering out sub-pixel rendering noise (e.g. anti-aliasing, transparency). " \
+                                                    "Defaults to 0.0 (any pixel change is reported) when not set.",
+                                       optional: true,
+                                       type: Float,
+                                       verify_block: proc do |value|
+                                                       UI.user_error! "diff_threshold must be between 0.0 and 1.0" unless value >= 0.0 && value < 1.0
+                                                     end)
         ] + Helper::SentryConfig.common_vcs_config_items
       end
 

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_snapshots.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_snapshots.rb
@@ -57,11 +57,11 @@ module Fastlane
                                        description: "Only report images as changed if their difference percentage exceeds this value (0.0–1.0). " \
                                                     "For example, 0.001 ignores changes affecting less than 0.1% of pixels. " \
                                                     "Useful for filtering out sub-pixel rendering noise (e.g. anti-aliasing, transparency). " \
-                                                    "Defaults to 0.0 (any pixel change is reported) when not set.",
+                                                    "Defaults to 0.0 (any pixel change is reported) when not set",
                                        optional: true,
                                        type: Float,
                                        verify_block: proc do |value|
-                                                       UI.user_error! "diff_threshold must be between 0.0 and 1.0" unless value >= 0.0 && value < 1.0
+                                                       UI.user_error! "diff_threshold must be between 0.0 and 1.0" unless value >= 0.0 && value <= 1.0
                                                      end)
         ] + Helper::SentryConfig.common_vcs_config_items
       end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_snapshots.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_snapshots.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        optional: true,
                                        type: Float,
                                        verify_block: proc do |value|
-                                                       UI.user_error! "diff_threshold must be between 0.0 and 1.0" unless value >= 0.0 && value <= 1.0
+                                                       UI.user_error! "diff_threshold must be between 0.0 and 1.0" unless value.between?(0.0, 1.0)
                                                      end)
         ] + Helper::SentryConfig.common_vcs_config_items
       end

--- a/spec/sentry_upload_snapshots_spec.rb
+++ b/spec/sentry_upload_snapshots_spec.rb
@@ -119,6 +119,60 @@ describe Fastlane do
           end").runner.execute(:test)
         end
       end
+
+      it "passes --diff-threshold when specified" do
+        Dir.mktmpdir do |path|
+          expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything,
+            ["snapshots", "upload", "--app-id", "com.example.app", "--diff-threshold", "0.001", path]
+          ).and_return(true)
+
+          described_class.new.parse("lane :test do
+              sentry_upload_snapshots(
+                org_slug: 'some_org',
+                auth_token: 'something123',
+                project_slug: 'some_project',
+                app_id: 'com.example.app',
+                path: '#{path}',
+                diff_threshold: 0.001)
+          end").runner.execute(:test)
+        end
+      end
+
+      it "omits --diff-threshold when not specified" do
+        Dir.mktmpdir do |path|
+          expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything, ["snapshots", "upload", "--app-id", "com.example.app", path]
+          ).and_return(true)
+
+          described_class.new.parse("lane :test do
+              sentry_upload_snapshots(
+                org_slug: 'some_org',
+                auth_token: 'something123',
+                project_slug: 'some_project',
+                app_id: 'com.example.app',
+                path: '#{path}')
+          end").runner.execute(:test)
+        end
+      end
+
+      it "raises an error when diff_threshold is out of range" do
+        Dir.mktmpdir do |path|
+          expect do
+            described_class.new.parse("lane :test do
+              sentry_upload_snapshots(
+                org_slug: 'some_org',
+                auth_token: 'something123',
+                project_slug: 'some_project',
+                app_id: 'com.example.app',
+                path: '#{path}',
+                diff_threshold: 1.5)
+            end").runner.execute(:test)
+          end.to raise_error("diff_threshold must be between 0.0 and 1.0")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What

Exposes the `--diff-threshold` flag from `sentry-cli` as a `diff_threshold` parameter in the `sentry_upload_snapshots` action.

## Why

The server-side default is `0.0`, meaning **any single pixel change** triggers a "changed" status. This is too strict for mobile screenshots — sub-pixel rendering differences from font smoothing, anti-aliasing, and transparency compositing (e.g. iOS Liquid Glass effects) produce small but non-zero diffs on every run, blocking PRs that made no intentional UI changes.

The reported diff value (e.g. `0.000002846` ≈ ~9 pixels out of a full-screen screenshot) rounds to "0%" in the UI, making it confusing to diagnose.

## Usage

```ruby
sentry_upload_snapshots(
  auth_token: ENV["SENTRY_AUTH_TOKEN"],
  org_slug: "my-org",
  project_slug: "my-project",
  path: screenshots_path,
  app_id: "com.example.app",
  diff_threshold: 0.001  # ignore changes affecting < 0.1% of pixels
)
```

- `0.001` — filters sub-pixel noise, catches anything affecting ≥ 0.1% of pixels
- Omitting the parameter preserves existing behavior (server default of `0.0`)

## Changes

- `sentry_upload_snapshots.rb`: adds optional `diff_threshold` (Float, 0.0–1.0) parameter; appends `--diff-threshold <value>` to the CLI command when set
- `sentry_upload_snapshots_spec.rb`: adds specs for presence, absence, and out-of-range validation

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0APJV7CSHM%3A1782998876.140689/?project=4510944073809921)

<!-- junior-session-footer:end -->