### PR TITLE
feat(build): Include dSYMs in IPA build uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Include dSYMs in IPA build uploads ([#531](https://github.com/getsentry/sentry-fastlane-plugin/pull/531))
+
 ## 2.6.3
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 ### Features
 
-- Include dSYMs in IPA build uploads ([#531](https://github.com/getsentry/sentry-fastlane-plugin/pull/531))
+- Add dSYM support to IPA build uploads. Pass `dsym_path` to `sentry_upload_build` to include symbols in build analysis:
+
+  ```ruby
+  sentry_upload_build(
+    ipa_path: "./build/MyApp.ipa",
+    dsym_path: "./build/MyApp.app.dSYM.zip"
+  )
+  ```
+
+  `dsym_path` accepts a path or array of paths to dSYM bundles, directories containing dSYMs, or ZIP archives. The dSYMs are also uploaded separately for event symbolication. Including dSYMs in IPA build analysis is supported when running on macOS with Apple silicon. ([#531](https://github.com/getsentry/sentry-fastlane-plugin/pull/531))
 
 ## 2.6.3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-sentry (2.5.7)
+    fastlane-plugin-sentry (2.6.3)
       os (~> 1.1, >= 1.1.4)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Upload build files to Sentry for improved symbolication and source context. Supp
 - **iOS**: `.xcarchive` (build archive) or `.ipa` (app bundle)
 - **Android**: `.apk` or `.aab` (App Bundle)
 
-Explicitly passed path parameters take precedence over SharedValues. For IPA uploads, use `dsym_path` to attach dSYM files for symbolication (IPAs typically don't embed symbols).
+Explicitly passed path parameters take precedence over SharedValues. dSYMs provided through `dsym_path` are uploaded for symbolication and are also included in IPA build analysis.
 
 ```ruby
 sentry_upload_build(
@@ -101,7 +101,7 @@ sentry_upload_build(
   project_slug: '...',
   # One of: xcarchive_path, ipa_path, apk_path, or aab_path (mutually exclusive)
   xcarchive_path: './build/MyApp.xcarchive', # or ipa_path, apk_path, aab_path
-  dsym_path: './build/MyApp.app.dSYM.zip', # Optional. For IPA/xcarchive - path or array of dSYM paths. Defaults to DSYM_OUTPUT_PATH from lane context when not specified
+  dsym_path: './build/MyApp.app.dSYM.zip', # Optional. Path or array of dSYM inputs for symbolication; with IPA uploads, also used for build analysis. Defaults to DSYM_OUTPUT_PATH from lane context when not specified
   # Optional git context parameters (can also be set via environment variables)
   head_sha: 'abc123...', # The SHA of the head of the current branch (or SENTRY_HEAD_SHA)
   base_sha: 'def456...', # The SHA of the base branch (or SENTRY_BASE_SHA)

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
@@ -26,6 +26,13 @@ module Fastlane
           File.absolute_path(build_path)
         ]
 
+        dsym_paths = resolve_dsym_paths(params, build_type)
+        if build_type == :ipa
+          dsym_paths.each do |path|
+            command.push("--dsym").push(path)
+          end
+        end
+
         Helper::SentryConfig.build_vcs_command(command, params)
 
         command << "--build-configuration" << params[:build_configuration] if params[:build_configuration]
@@ -48,8 +55,7 @@ module Fastlane
         Helper::SentryHelper.call_sentry_cli(params, command)
         UI.success("Successfully uploaded build file: #{build_path}")
 
-        # Upload dSYMs for iOS builds when dsym_path is provided or DSYM_OUTPUT_PATH is set
-        upload_dsym_if_requested(params, build_type)
+        upload_dsyms(params, dsym_paths)
       end
 
       #####################################################
@@ -63,8 +69,9 @@ module Fastlane
       def self.details
         "This action allows you to upload build files to Sentry. Supported formats include iOS build archives (.xcarchive), " \
           "iOS app bundles (.ipa), Android APK files (.apk), and Android App Bundles (.aab). IPA files typically don't " \
-          "embed dSYMs—use the dsym_path parameter to upload symbols for proper symbolication, or call sentry_debug_files_upload " \
-          "separately. The action supports optional git-related parameters for enhanced context including commit SHAs, " \
+          "embed dSYMs; use dsym_path to provide them for build analysis and event symbolication, or call " \
+          "sentry_debug_files_upload to upload them only for symbolication. The action supports optional git-related " \
+          "parameters for enhanced context including commit SHAs, " \
           "branch names, repository information, and pull request details. Install groups can be specified to control update " \
           "visibility between builds."
       end
@@ -102,7 +109,7 @@ module Fastlane
                                          UI.user_error!("Path '#{value}' is not an AAB") unless File.extname(value).casecmp('.aab').zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :ipa_path,
-                                       description: "Path to your iOS app bundle (.ipa). Defaults to IPA_OUTPUT_PATH from lane context. For symbolication, use dsym_path or call sentry_debug_files_upload separately. Mutually exclusive with xcarchive_path, apk_path, and aab_path",
+                                       description: "Path to your iOS app bundle (.ipa). Defaults to IPA_OUTPUT_PATH from lane context. Use dsym_path to include dSYMs in build analysis and event symbolication. Mutually exclusive with xcarchive_path, apk_path, and aab_path",
                                        optional: true,
                                        conflicting_options: [:xcarchive_path, :apk_path, :aab_path],
                                        verify_block: proc do |value|
@@ -112,7 +119,7 @@ module Fastlane
                                          UI.user_error!("Path '#{value}' is not an IPA") unless File.extname(value).casecmp('.ipa').zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
-                                       description: "Path to dSYM file(s) for symbolication. Use when uploading IPA (IPAs typically don't embed dSYMs). Can be a path or array of paths. Defaults to DSYM_OUTPUT_PATH from lane context for iOS builds when not specified",
+                                       description: "Path to dSYM bundle(s), a directory containing dSYM bundles, or zipped dSYMs. For IPA uploads, all inputs are included in the build upload. All inputs are also uploaded for event symbolication. Can be a path or array of paths. Defaults to DSYM_OUTPUT_PATH from lane context for iOS builds when not specified",
                                        optional: true,
                                        type: Array,
                                        skip_type_validation: true)
@@ -180,13 +187,17 @@ module Fastlane
         end
       end
 
-      def self.upload_dsym_if_requested(params, build_type)
+      def self.resolve_dsym_paths(params, build_type)
         dsym_paths = Array(params[:dsym_path]).reject { |p| p.nil? || p.to_s.empty? }
         # For iOS builds, use DSYM_OUTPUT_PATH from lane context when dsym_path not specified
         if dsym_paths.empty? && [:ipa, :xcarchive].include?(build_type)
           dsym_from_context = Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH]
           dsym_paths = [dsym_from_context] if dsym_from_context && !dsym_from_context.to_s.empty?
         end
+        dsym_paths
+      end
+
+      def self.upload_dsyms(params, dsym_paths)
         return if dsym_paths.empty?
 
         uploaded_count = 0

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
@@ -27,7 +27,8 @@ module Fastlane
         ]
 
         dsym_paths = resolve_dsym_paths(params, build_type)
-        if build_type == :ipa
+        supports_dsym_build_upload = OS.mac? && OS.host_cpu == 'arm64'
+        if build_type == :ipa && supports_dsym_build_upload
           dsym_paths.each do |path|
             next unless File.exist?(path)
 
@@ -204,17 +205,16 @@ module Fastlane
 
         uploaded_count = 0
         dsym_paths.each do |path|
-          next unless File.exist?(path)
+          unless File.exist?(path)
+            UI.important("Skipping missing dSYM path: #{path}")
+            next
+          end
 
           command = ["debug-files", "upload", File.absolute_path(path), "--type", "dsym"]
           Helper::SentryHelper.call_sentry_cli(params, command)
           uploaded_count += 1
         end
-        if uploaded_count > 0
-          UI.success("Successfully uploaded dSYM files")
-        elsif dsym_paths.any?
-          UI.verbose("No dSYM files were uploaded: none of the specified paths exist (#{dsym_paths.join(', ')})")
-        end
+        UI.success("Successfully uploaded dSYM files") if uploaded_count > 0
       end
     end
   end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
@@ -29,6 +29,8 @@ module Fastlane
         dsym_paths = resolve_dsym_paths(params, build_type)
         if build_type == :ipa
           dsym_paths.each do |path|
+            next unless File.exist?(path)
+
             command.push("--dsym").push(path)
           end
         end

--- a/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
+++ b/lib/fastlane/plugin/sentry/actions/sentry_upload_build.rb
@@ -119,7 +119,7 @@ module Fastlane
                                          UI.user_error!("Path '#{value}' is not an IPA") unless File.extname(value).casecmp('.ipa').zero?
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
-                                       description: "Path to dSYM bundle(s), a directory containing dSYM bundles, or zipped dSYMs. For IPA uploads, all inputs are included in the build upload. All inputs are also uploaded for event symbolication. Can be a path or array of paths. Defaults to DSYM_OUTPUT_PATH from lane context for iOS builds when not specified",
+                                       description: "Path or array of paths to a dSYM bundle, a directory containing dSYM bundles, or a ZIP archive containing either. For IPA uploads, inputs are included in build analysis and uploaded for event symbolication. Defaults to DSYM_OUTPUT_PATH from lane context for iOS builds when omitted",
                                        optional: true,
                                        type: Array,
                                        skip_type_validation: true)

--- a/spec/sentry_upload_build_spec.rb
+++ b/spec/sentry_upload_build_spec.rb
@@ -577,6 +577,7 @@ describe Fastlane do
             if call_count == 1
               expect(command[0]).to eq("build")
               expect(command[1]).to eq("upload")
+              expect(command).to include("--dsym", mock_dsym_path)
             elsif call_count == 2
               expect(command[0]).to eq("debug-files")
               expect(command[1]).to eq("upload")
@@ -591,6 +592,52 @@ describe Fastlane do
               project_slug: 'test-project',
               ipa_path: '#{mock_ipa_path}',
               dsym_path: '#{mock_dsym_path}')
+          end").runner.execute(:test)
+        end
+
+        it "forwards dSYM bundle and directory paths unchanged in IPA build uploads" do
+          mock_ipa_path = './assets/Test.ipa'
+          mock_dsym_bundle = './assets/Test.app.dSYM'
+          mock_dsym_directory = './assets/dSYMs'
+
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODEBUILD_ARCHIVE] = nil
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(mock_ipa_path).and_return(true)
+          allow(File).to receive(:exist?).with(mock_dsym_bundle).and_return(true)
+          allow(File).to receive(:exist?).with(mock_dsym_directory).and_return(true)
+          allow(File).to receive(:exist?).with(nil).and_return(false)
+          allow(File).to receive(:extname).and_call_original
+          allow(File).to receive(:extname).with(mock_ipa_path).and_return('.ipa')
+
+          expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything,
+            [
+              "build",
+              "upload",
+              a_string_ending_with("/assets/Test.ipa"),
+              "--dsym",
+              mock_dsym_bundle,
+              "--dsym",
+              mock_dsym_directory
+            ]
+          ).ordered.and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything,
+            ["debug-files", "upload", a_string_ending_with("/assets/Test.app.dSYM"), "--type", "dsym"]
+          ).ordered.and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything,
+            ["debug-files", "upload", a_string_ending_with("/assets/dSYMs"), "--type", "dsym"]
+          ).ordered.and_return(true)
+
+          described_class.new.parse("lane :test do
+            sentry_upload_build(
+              auth_token: 'test-token',
+              org_slug: 'test-org',
+              project_slug: 'test-project',
+              ipa_path: '#{mock_ipa_path}',
+              dsym_path: ['#{mock_dsym_bundle}', '#{mock_dsym_directory}'])
           end").runner.execute(:test)
         end
 

--- a/spec/sentry_upload_build_spec.rb
+++ b/spec/sentry_upload_build_spec.rb
@@ -479,6 +479,10 @@ describe Fastlane do
       end
 
       describe "IPA upload" do
+        before do
+          allow(OS).to receive_messages(mac?: true, host_cpu: 'arm64')
+        end
+
         it "calls sentry-cli with IPA path" do
           mock_ipa_path = './assets/Test.ipa'
 
@@ -608,6 +612,7 @@ describe Fastlane do
           allow(File).to receive(:extname).with(mock_ipa_path).and_return('.ipa')
 
           expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+          expect(FastlaneCore::UI).to receive(:important).with("Skipping missing dSYM path: #{missing_dsym_path}")
           expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli) do |_params, command|
             expect(command[0]).to eq("build")
             expect(command[1]).to eq("upload")
@@ -622,6 +627,39 @@ describe Fastlane do
               project_slug: 'test-project',
               ipa_path: '#{mock_ipa_path}',
               dsym_path: '#{missing_dsym_path}')
+          end").runner.execute(:test)
+        end
+
+        it "does not include dSYMs in IPA build uploads on x86_64" do
+          mock_ipa_path = './assets/Test.ipa'
+          mock_dsym_path = './assets/SwiftExample.app.dSYM.zip'
+
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODEBUILD_ARCHIVE] = nil
+          allow(OS).to receive(:host_cpu).and_return('x86_64')
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(mock_ipa_path).and_return(true)
+          allow(File).to receive(:exist?).with(mock_dsym_path).and_return(true)
+          allow(File).to receive(:exist?).with(nil).and_return(false)
+          allow(File).to receive(:extname).and_call_original
+          allow(File).to receive(:extname).with(mock_ipa_path).and_return('.ipa')
+
+          expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything,
+            ["build", "upload", a_string_ending_with("/assets/Test.ipa")]
+          ).ordered.and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli).with(
+            anything,
+            ["debug-files", "upload", a_string_ending_with("/assets/SwiftExample.app.dSYM.zip"), "--type", "dsym"]
+          ).ordered.and_return(true)
+
+          described_class.new.parse("lane :test do
+            sentry_upload_build(
+              auth_token: 'test-token',
+              org_slug: 'test-org',
+              project_slug: 'test-project',
+              ipa_path: '#{mock_ipa_path}',
+              dsym_path: '#{mock_dsym_path}')
           end").runner.execute(:test)
         end
 

--- a/spec/sentry_upload_build_spec.rb
+++ b/spec/sentry_upload_build_spec.rb
@@ -595,6 +595,36 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
+        it "skips missing dSYM paths" do
+          mock_ipa_path = './assets/Test.ipa'
+          missing_dsym_path = './assets/Missing.app.dSYM'
+
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODEBUILD_ARCHIVE] = nil
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(mock_ipa_path).and_return(true)
+          allow(File).to receive(:exist?).with(missing_dsym_path).and_return(false)
+          allow(File).to receive(:exist?).with(nil).and_return(false)
+          allow(File).to receive(:extname).and_call_original
+          allow(File).to receive(:extname).with(mock_ipa_path).and_return('.ipa')
+
+          expect(Fastlane::Helper::SentryConfig).to receive(:parse_api_params).and_return(true)
+          expect(Fastlane::Helper::SentryHelper).to receive(:call_sentry_cli) do |_params, command|
+            expect(command[0]).to eq("build")
+            expect(command[1]).to eq("upload")
+            expect(command).not_to include("--dsym")
+            true
+          end
+
+          described_class.new.parse("lane :test do
+            sentry_upload_build(
+              auth_token: 'test-token',
+              org_slug: 'test-org',
+              project_slug: 'test-project',
+              ipa_path: '#{mock_ipa_path}',
+              dsym_path: '#{missing_dsym_path}')
+          end").runner.execute(:test)
+        end
+
         it "forwards dSYM bundle and directory paths unchanged in IPA build uploads" do
           mock_ipa_path = './assets/Test.ipa'
           mock_dsym_bundle = './assets/Test.app.dSYM'


### PR DESCRIPTION
## Summary

- Include resolved `dsym_path` inputs in IPA build uploads for build analysis.
- Correct the stale plugin version in `Gemfile.lock`.